### PR TITLE
Syscall addon

### DIFF
--- a/addons/syscalls/syscallinfo.py
+++ b/addons/syscalls/syscallinfo.py
@@ -13,6 +13,9 @@ class SyscallTable:
 		entry = collections.OrderedDict()
 
 		for i in range(len(parts)):
+			if identifiers[i] == "Definition":
+				parts[i] = parts[i].split(":")[0]
+				
 			entry[identifiers[i]] = parts[i]
 
 		return entry

--- a/addons/syscalls/syscallinfo.py
+++ b/addons/syscalls/syscallinfo.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+import collections, os
+
+class SyscallTable:
+	def __init__(self, filename):
+		self.source = filename
+		self.entries = collections.OrderedDict()
+		#self.identifiers = []
+
+		self.parse_table(filename)
+
+	def getEntryDict(self, parts, identifiers):
+		entry = collections.OrderedDict()
+
+		for i in range(len(parts)):
+			entry[identifiers[i]] = parts[i]
+
+		return entry
+
+	def parse_table(self, filename):		
+		lines = []
+		
+		with open(filename) as f:
+			lines = f.readlines()
+
+		# retrieve identifiers from first line
+		identifiers = lines[0].strip().split("\t")
+
+		for line in lines[1:]:
+			parts = line.split("\t")
+			self.entries[parts[1]] = self.getEntryDict(line.split("\t"), identifiers)
+
+	def getEntryByID(self, idx):
+		for entry in self.entries:
+			if self.entries[entry]["#"] == str(idx):
+				return self.entries[entry]
+
+		return None
+
+	def getEntryByName(self, name):
+		if name in self.entries:
+			return self.entries[name]
+
+		return None
+
+	def getInfoMessage(self, entry):
+		if entry:
+			msg = ""
+						
+			for part in entry:
+				msg += "{0:15} : {1}\n".format(part, entry[part])
+			
+			return msg
+
+		return None
+
+	def getInfoMessageByID(self, idx):
+		entry = self.getEntryByID(idx)
+		return self.getInfoMessage(entry)
+
+	def getInfoMessageByName(self, name):
+		entry = self.getEntryByName(name)
+		return self.getInfoMessage(entry)
+
+
+class SyscallInfo:
+	def __init__(self, basedir):
+		self.tables = {}
+
+		for table in os.listdir(basedir):
+			filename = os.path.join(basedir, table)
+
+			self.tables[table] = SyscallTable(filename)
+
+	def getAvailableArchitectures(self):
+		return self.tables.keys()
+
+	def getArch(self, arch):
+		if arch in self.tables:
+			return self.tables[arch]
+
+		return None

--- a/addons/syscalls/tables/arm
+++ b/addons/syscalls/tables/arm
@@ -9,7 +9,7 @@
 9437192	creat	0x900008	const char *pathname	umode_t mode	-	-	-	-	fs/open.c:1079
 9437193	link	0x900009	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3152
 9437194	unlink	0x90000a	const char *pathname	-	-	-	-	-	fs/namei.c:2979
-9437195	execve	0x90000b	const char *filenamei	const char *const *argv	const char *const *envp	-	-	-	arch/arm/kernel/sys_arm.c:65
+9437195	execve	0x90000b	const char *filename	const char *const *argv	const char *const *envp	-	-	-	arch/arm/kernel/sys_arm.c:65
 9437196	chdir	0x90000c	const char *filename	-	-	-	-	-	fs/open.c:375
 9437197	time	0x90000d	time_t *tloc	-	-	-	-	-	kernel/time.c:62
 9437198	mknod	0x90000e	const char *filename	umode_t mode	unsigned dev	-	-	-	fs/namei.c:2693

--- a/addons/syscalls/tables/arm
+++ b/addons/syscalls/tables/arm
@@ -1,0 +1,346 @@
+#	Name	r7	r0	r1	r2	r3	r4	r5	Definition
+9437184	restart_syscall	0x900000	-	-	-	-	-	-	kernel/signal.c:2501
+9437185	exit	0x900001	int error_code	-	-	-	-	-	kernel/exit.c:1095
+9437186	fork	0x900002	-	-	-	-	-	-	arch/arm/kernel/sys_arm.c:34
+9437187	read	0x900003	unsigned int fd	char *buf	size_t count	-	-	-	fs/read_write.c:460
+9437188	write	0x900004	unsigned int fd	const char *buf	size_t count	-	-	-	fs/read_write.c:477
+9437189	open	0x900005	const char *filename	int flags	umode_t mode	-	-	-	fs/open.c:1046
+9437190	close	0x900006	unsigned int fd	-	-	-	-	-	fs/open.c:1117
+9437192	creat	0x900008	const char *pathname	umode_t mode	-	-	-	-	fs/open.c:1079
+9437193	link	0x900009	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3152
+9437194	unlink	0x90000a	const char *pathname	-	-	-	-	-	fs/namei.c:2979
+9437195	execve	0x90000b	const char *filenamei	const char *const *argv	const char *const *envp	-	-	-	arch/arm/kernel/sys_arm.c:65
+9437196	chdir	0x90000c	const char *filename	-	-	-	-	-	fs/open.c:375
+9437197	time	0x90000d	time_t *tloc	-	-	-	-	-	kernel/time.c:62
+9437198	mknod	0x90000e	const char *filename	umode_t mode	unsigned dev	-	-	-	fs/namei.c:2693
+9437199	chmod	0x90000f	const char *filename	umode_t mode	-	-	-	-	fs/open.c:499
+9437200	lchown	0x900010	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+9437203	lseek	0x900013	unsigned int fd	off_t offset	unsigned int origin	-	-	-	fs/read_write.c:230
+9437204	getpid	0x900014	-	-	-	-	-	-	kernel/timer.c:1413
+9437205	mount	0x900015	char *dev_name	char *dir_name	char *type	unsigned long flags	void *data	-	fs/namespace.c:2362
+9437206	umount	0x900016	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+9437207	setuid	0x900017	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+9437208	getuid	0x900018	-	-	-	-	-	-	kernel/timer.c:1435
+9437209	stime	0x900019	time_t *tptr	-	-	-	-	-	kernel/time.c:81
+9437210	ptrace	0x90001a	long request	long pid	unsigned long addr	unsigned long data	-	-	kernel/ptrace.c:857
+9437211	alarm	0x90001b	unsigned int seconds	-	-	-	-	-	kernel/timer.c:1390
+9437213	pause	0x90001d	-	-	-	-	-	-	kernel/signal.c:3245
+9437214	utime	0x90001e	char *filename	struct utimbuf *times	-	-	-	-	fs/utimes.c:27
+9437217	access	0x900021	const char *filename	int mode	-	-	-	-	fs/open.c:370
+9437218	nice	0x900022	int increment	-	-	-	-	-	kernel/sched/core.c:4119
+9437220	sync	0x900024	-	-	-	-	-	-	fs/sync.c:98
+9437221	kill	0x900025	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2841
+9437222	rename	0x900026	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3403
+9437223	mkdir	0x900027	const char *pathname	umode_t mode	-	-	-	-	fs/namei.c:2751
+9437224	rmdir	0x900028	const char *pathname	-	-	-	-	-	fs/namei.c:2870
+9437225	dup	0x900029	unsigned int fildes	-	-	-	-	-	fs/fcntl.c:131
+9437226	pipe	0x90002a	int *fildes	-	-	-	-	-	fs/pipe.c:1149
+9437227	times	0x90002b	struct tms *tbuf	-	-	-	-	-	kernel/sys.c:1058
+9437229	brk	0x90002d	unsigned long brk	-	-	-	-	-	mm/mmap.c:246
+9437230	setgid	0x90002e	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+9437231	getgid	0x90002f	-	-	-	-	-	-	kernel/timer.c:1447
+9437233	geteuid	0x900031	-	-	-	-	-	-	kernel/timer.c:1441
+9437234	getegid	0x900032	-	-	-	-	-	-	kernel/timer.c:1453
+9437235	acct	0x900033	const char *name	-	-	-	-	-	kernel/acct.c:255
+9437236	umount2	0x900034	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+9437238	ioctl	0x900036	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/ioctl.c:604
+9437239	fcntl	0x900037	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:442
+9437241	setpgid	0x900039	pid_t pid	pid_t pgid	-	-	-	-	kernel/sys.c:1083
+9437244	umask	0x90003c	int mask	-	-	-	-	-	kernel/sys.c:1782
+9437245	chroot	0x90003d	const char *filename	-	-	-	-	-	fs/open.c:422
+9437246	ustat	0x90003e	unsigned dev	struct ustat *ubuf	-	-	-	-	fs/statfs.c:222
+9437247	dup2	0x90003f	unsigned int oldfd	unsigned int newfd	-	-	-	-	fs/fcntl.c:116
+9437248	getppid	0x900040	-	-	-	-	-	-	kernel/timer.c:1424
+9437249	getpgrp	0x900041	-	-	-	-	-	-	kernel/sys.c:1184
+9437250	setsid	0x900042	-	-	-	-	-	-	kernel/sys.c:1219
+9437251	sigaction	0x900043	int sig	const struct old_sigaction *act	struct old_sigaction *oact	-	-	-	arch/arm/kernel/signal.c:73
+9437254	setreuid	0x900046	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+9437255	setregid	0x900047	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+9437256	sigsuspend	0x900048	int restart	unsigned long oldmask	old_sigset_t mask	-	-	-	arch/arm/kernel/signal.c:65
+9437257	sigpending	0x900049	old_sigset_t *set	-	-	-	-	-	kernel/signal.c:3107
+9437258	sethostname	0x90004a	char *name	int len	-	-	-	-	kernel/sys.c:1365
+9437259	setrlimit	0x90004b	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1641
+9437260	getrlimit	0x90004c	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+9437261	getrusage	0x90004d	int who	struct rusage *ru	-	-	-	-	kernel/sys.c:1774
+9437262	gettimeofday	0x90004e	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:101
+9437263	settimeofday	0x90004f	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:179
+9437264	getgroups	0x900050	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+9437265	setgroups	0x900051	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+9437266	select	0x900052	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+9437267	symlink	0x900053	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3039
+9437269	readlink	0x900055	const char *path	char *buf	int bufsiz	-	-	-	fs/stat.c:321
+9437270	uselib	0x900056	const char *library	-	-	-	-	-	fs/exec.c:116
+9437271	swapon	0x900057	const char *specialfile	int swap_flags	-	-	-	-	mm/swapfile.c:1996
+9437272	reboot	0x900058	int magic1	int magic2	unsigned int cmd	void *arg	-	-	kernel/sys.c:432
+9437273	readdir	0x900059	unsigned int fd	struct old_linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:105
+9437274	mmap	0x90005a	struct mmap_arg_struct *arg	-	-	-	-	-	mm/mmap.c:1153
+9437275	munmap	0x90005b	unsigned long addr	size_t len	-	-	-	-	mm/mmap.c:2141
+9437276	truncate	0x90005c	const char *path	long length	-	-	-	-	fs/open.c:128
+9437277	ftruncate	0x90005d	unsigned int fd	unsigned long length	-	-	-	-	fs/open.c:178
+9437278	fchmod	0x90005e	unsigned int fd	umode_t mode	-	-	-	-	fs/open.c:472
+9437279	fchown	0x90005f	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+9437280	getpriority	0x900060	int which	int who	-	-	-	-	kernel/sys.c:241
+9437281	setpriority	0x900061	int which	int who	int niceval	-	-	-	kernel/sys.c:172
+9437283	statfs	0x900063	const char *pathname	struct statfs *buf	-	-	-	-	fs/statfs.c:166
+9437284	fstatfs	0x900064	unsigned int fd	struct statfs *buf	-	-	-	-	fs/statfs.c:187
+9437286	socketcall	0x900066	int call	unsigned long *args	-	-	-	-	net/socket.c:2355
+9437287	syslog	0x900067	int type	char *buf	int len	-	-	-	kernel/printk.c:1195
+9437288	setitimer	0x900068	int which	struct itimerval *value	struct itimerval *ovalue	-	-	-	kernel/itimer.c:278
+9437289	getitimer	0x900069	int which	struct itimerval *value	-	-	-	-	kernel/itimer.c:103
+9437290	stat	0x90006a	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:155
+9437291	lstat	0x90006b	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:168
+9437292	fstat	0x90006c	unsigned int fd	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:181
+9437295	vhangup	0x90006f	-	-	-	-	-	-	fs/open.c:1156
+9437297	syscall	0x900071	-	-	-	-	-	-	arch/arm/kernel/entry-common.S:502
+9437298	wait4	0x900072	pid_t upid	int *stat_addr	int options	struct rusage *ru	-	-	kernel/exit.c:1834
+9437299	swapoff	0x900073	const char *specialfile	-	-	-	-	-	mm/swapfile.c:1539
+9437300	sysinfo	0x900074	struct sysinfo *info	-	-	-	-	-	kernel/timer.c:1641
+9437301	ipc	0x900075	unsigned int call	int first	unsigned long second	unsigned long third	void *ptr	long fifth	ipc/syscall.c:16
+9437302	fsync	0x900076	unsigned int fd	-	-	-	-	-	fs/sync.c:201
+9437303	sigreturn	0x900077	-	-	-	-	-	-	arch/arm/kernel/signal.c:264
+9437304	clone	0x900078	unsigned long clone_flags	unsigned long newsp	int *parent_tidptr	int tls_val	int *child_tidptr	-	arch/arm/kernel/sys_arm.c:47
+9437305	setdomainname	0x900079	char *name	int len	-	-	-	-	kernel/sys.c:1416
+9437306	uname	0x90007a	struct old_utsname *name	-	-	-	-	-	kernel/sys.c:1311
+9437308	adjtimex	0x90007c	struct timex *txc_p	-	-	-	-	-	kernel/time.c:200
+9437309	mprotect	0x90007d	unsigned long start	size_t len	unsigned long prot	-	-	-	mm/mprotect.c:232
+9437310	sigprocmask	0x90007e	int how	old_sigset_t *nset	old_sigset_t *oset	-	-	-	kernel/signal.c:3125
+9437312	init_module	0x900080	void *umod	unsigned long len	const char *uargs	-	-	-	kernel/module.c:3010
+9437313	delete_module	0x900081	const char *name_user	unsigned int flags	-	-	-	-	kernel/module.c:768
+9437315	quotactl	0x900083	unsigned int cmd	const char *special	qid_t id	void *addr	-	-	fs/quota/quota.c:346
+9437316	getpgid	0x900084	pid_t pid	-	-	-	-	-	kernel/sys.c:1154
+9437317	fchdir	0x900085	unsigned int fd	-	-	-	-	-	fs/open.c:396
+9437318	bdflush	0x900086	int func	long data	-	-	-	-	fs/buffer.c:3130
+9437319	sysfs	0x900087	int option	unsigned long arg1	unsigned long arg2	-	-	-	fs/filesystems.c:183
+9437320	personality	0x900088	unsigned int personality	-	-	-	-	-	kernel/exec_domain.c:182
+9437322	setfsuid	0x90008a	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+9437323	setfsgid	0x90008b	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+9437324	_llseek	0x90008c	unsigned int fd	unsigned long offset_high	unsigned long offset_low	loff_t *result	unsigned int origin	-	fs/read_write.c:254
+9437325	getdents	0x90008d	unsigned int fd	struct linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:191
+9437326	_newselect	0x90008e	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+9437327	flock	0x90008f	unsigned int fd	unsigned int cmd	-	-	-	-	fs/locks.c:1636
+9437328	msync	0x900090	unsigned long start	size_t len	int flags	-	-	-	mm/msync.c:31
+9437329	readv	0x900091	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:787
+9437330	writev	0x900092	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:808
+9437331	getsid	0x900093	pid_t pid	-	-	-	-	-	kernel/sys.c:1191
+9437332	fdatasync	0x900094	unsigned int fd	-	-	-	-	-	fs/sync.c:206
+9437333	_sysctl	0x900095	struct __sysctl_args *args	-	-	-	-	-	kernel/sysctl_binary.c:1444
+9437334	mlock	0x900096	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:482
+9437335	munlock	0x900097	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:512
+9437336	mlockall	0x900098	int flags	-	-	-	-	-	mm/mlock.c:549
+9437337	munlockall	0x900099	-	-	-	-	-	-	mm/mlock.c:582
+9437338	sched_setparam	0x90009a	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4477
+9437339	sched_getparam	0x90009b	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4512
+9437340	sched_setscheduler	0x90009c	pid_t pid	int policy	struct sched_param *param	-	-	-	kernel/sched/core.c:4462
+9437341	sched_getscheduler	0x90009d	pid_t pid	-	-	-	-	-	kernel/sched/core.c:4486
+9437342	sched_yield	0x90009e	-	-	-	-	-	-	kernel/sched/core.c:4711
+9437343	sched_get_priority_max	0x90009f	int policy	-	-	-	-	-	kernel/sched/core.c:4935
+9437344	sched_get_priority_min	0x9000a0	int policy	-	-	-	-	-	kernel/sched/core.c:4960
+9437345	sched_rr_get_interval	0x9000a1	pid_t pid	struct timespec *interval	-	-	-	-	kernel/sched/core.c:4985
+9437346	nanosleep	0x9000a2	struct timespec *rqtp	struct timespec *rmtp	-	-	-	-	kernel/hrtimer.c:1621
+9437347	mremap	0x9000a3	unsigned long addr	unsigned long old_len	unsigned long new_len	unsigned long flags	unsigned long new_addr	-	mm/mremap.c:431
+9437348	setresuid	0x9000a4	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+9437349	getresuid	0x9000a5	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+9437352	poll	0x9000a8	struct pollfd *ufds	unsigned int nfds	int timeout_msecs	-	-	-	fs/select.c:908
+9437353	nfsservctl	-	-	-	-	-	-	-	Not implemented
+9437354	setresgid	0x9000aa	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+9437355	getresgid	0x9000ab	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+9437356	prctl	0x9000ac	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	kernel/sys.c:1999
+9437357	rt_sigreturn	0x9000ad	-	-	-	-	-	-	arch/arm/kernel/signal.c:294
+9437358	rt_sigaction	0x9000ae	int sig	const struct sigaction *act	struct sigaction *oact	size_t sigsetsize	-	-	kernel/signal.c:3174
+9437359	rt_sigprocmask	0x9000af	int how	sigset_t *nset	sigset_t *oset	size_t sigsetsize	-	-	kernel/signal.c:2591
+9437360	rt_sigpending	0x9000b0	sigset_t *set	size_t sigsetsize	-	-	-	-	kernel/signal.c:2651
+9437361	rt_sigtimedwait	0x9000b1	const sigset_t *uthese	siginfo_t *uinfo	const struct timespec *uts	size_t sigsetsize	-	-	kernel/signal.c:2805
+9437362	rt_sigqueueinfo	0x9000b2	pid_t pid	int sig	siginfo_t *uinfo	-	-	-	kernel/signal.c:2938
+9437363	rt_sigsuspend	0x9000b3	sigset_t *unewset	size_t sigsetsize	-	-	-	-	kernel/signal.c:3274
+9437364	pread64	0x9000b4	char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:495
+9437365	pwrite64	0x9000b5	const char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:524
+9437366	chown	0x9000b6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+9437367	getcwd	0x9000b7	char *buf	unsigned long size	-	-	-	-	fs/dcache.c:2885
+9437368	capget	0x9000b8	cap_user_header_t header	cap_user_data_t dataptr	-	-	-	-	kernel/capability.c:158
+9437369	capset	0x9000b9	cap_user_header_t header	const cap_user_data_t data	-	-	-	-	kernel/capability.c:232
+9437370	sigaltstack	-	-	-	-	-	-	-	Not implemented
+9437371	sendfile	0x9000bb	int out_fd	int in_fd	off_t *offset	size_t count	-	-	fs/read_write.c:973
+9437374	vfork	0x9000be	-	-	-	-	-	-	arch/arm/kernel/sys_arm.c:57
+9437375	ugetrlimit	0x9000bf	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+9437376	mmap2	0x9000c0	unsigned long addr	unsigned long len	unsigned long prot	unsigned long flags	unsigned long fd	unsigned long pgoff	mm/mmap.c:1105
+9437377	truncate64	0x9000c1	loff_t length	-	-	-	-	-	fs/open.c:188
+9437378	ftruncate64	0x9000c2	loff_t length	-	-	-	-	-	fs/open.c:200
+9437379	stat64	0x9000c3	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:372
+9437380	lstat64	0x9000c4	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:384
+9437381	fstat64	0x9000c5	unsigned long fd	struct stat64 *statbuf	-	-	-	-	fs/stat.c:396
+9437382	lchown32	0x9000c6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+9437383	getuid32	0x9000c7	-	-	-	-	-	-	kernel/timer.c:1435
+9437384	getgid32	0x9000c8	-	-	-	-	-	-	kernel/timer.c:1447
+9437385	geteuid32	0x9000c9	-	-	-	-	-	-	kernel/timer.c:1441
+9437386	getegid32	0x9000ca	-	-	-	-	-	-	kernel/timer.c:1453
+9437387	setreuid32	0x9000cb	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+9437388	setregid32	0x9000cc	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+9437389	getgroups32	0x9000cd	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+9437390	setgroups32	0x9000ce	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+9437391	fchown32	0x9000cf	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+9437392	setresuid32	0x9000d0	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+9437393	getresuid32	0x9000d1	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+9437394	setresgid32	0x9000d2	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+9437395	getresgid32	0x9000d3	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+9437396	chown32	0x9000d4	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+9437397	setuid32	0x9000d5	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+9437398	setgid32	0x9000d6	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+9437399	setfsuid32	0x9000d7	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+9437400	setfsgid32	0x9000d8	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+9437401	getdents64	0x9000d9	unsigned int fd	struct linux_dirent64 *dirent	unsigned int count	-	-	-	fs/readdir.c:272
+9437402	pivot_root	0x9000da	const char *new_root	const char *put_old	-	-	-	-	fs/namespace.c:2453
+9437403	mincore	0x9000db	unsigned long start	size_t len	unsigned char *vec	-	-	-	mm/mincore.c:266
+9437404	madvise	0x9000dc	unsigned long start	size_t len_in	int behavior	-	-	-	mm/madvise.c:362
+9437405	fcntl64	0x9000dd	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:468
+9437408	gettid	0x9000e0	-	-	-	-	-	-	kernel/timer.c:1569
+9437409	readahead	0x9000e1	loff_t offset size_t count	-	-	-	-	-	mm/readahead.c:579
+9437410	setxattr	0x9000e2	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:361
+9437411	lsetxattr	0x9000e3	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:380
+9437412	fsetxattr	0x9000e4	int fd	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:399
+9437413	getxattr	0x9000e5	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:459
+9437414	lgetxattr	0x9000e6	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:473
+9437415	fgetxattr	0x9000e7	int fd	const char *name	void *value	size_t size	-	-	fs/xattr.c:487
+9437416	listxattr	0x9000e8	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:541
+9437417	llistxattr	0x9000e9	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:555
+9437418	flistxattr	0x9000ea	int fd	char *list	size_t size	-	-	-	fs/xattr.c:569
+9437419	removexattr	0x9000eb	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:602
+9437420	lremovexattr	0x9000ec	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:620
+9437421	fremovexattr	0x9000ed	int fd	const char *name	-	-	-	-	fs/xattr.c:638
+9437422	tkill	0x9000ee	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2923
+9437423	sendfile64	0x9000ef	int out_fd	int in_fd	loff_t *offset	size_t count	-	-	fs/read_write.c:992
+9437424	futex	0x9000f0	u32 *uaddr	int op	u32 val	struct timespec *utime	u32 *uaddr2	u32 val3	kernel/futex.c:2680
+9437425	sched_setaffinity	0x9000f1	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4626
+9437426	sched_getaffinity	0x9000f2	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4677
+9437427	io_setup	0x9000f3	unsigned nr_events	aio_context_t *ctxp	-	-	-	-	fs/aio.c:1298
+9437428	io_destroy	0x9000f4	aio_context_t ctx	-	-	-	-	-	fs/aio.c:1334
+9437429	io_getevents	0x9000f5	aio_context_t ctx_id	long min_nr	long nr	struct io_event *events	struct timespec *timeout	-	fs/aio.c:1844
+9437430	io_submit	0x9000f6	aio_context_t ctx_id	long nr	struct iocb * *iocbpp	-	-	-	fs/aio.c:1746
+9437431	io_cancel	0x9000f7	aio_context_t ctx_id	struct iocb *iocb	struct io_event *result	-	-	-	fs/aio.c:1781
+9437432	exit_group	0x9000f8	int error_code	-	-	-	-	-	kernel/exit.c:1136
+9437433	lookup_dcookie	0x9000f9	char *buf size_t len	-	-	-	-	-	fs/dcookies.c:148
+9437434	epoll_create	0x9000fa	int size	-	-	-	-	-	fs/eventpoll.c:1668
+9437435	epoll_ctl	0x9000fb	int epfd	int op	int fd	struct epoll_event *event	-	-	fs/eventpoll.c:1681
+9437436	epoll_wait	0x9000fc	int epfd	struct epoll_event *events	int maxevents	int timeout	-	-	fs/eventpoll.c:1809
+9437437	remap_file_pages	0x9000fd	unsigned long start	unsigned long size	unsigned long prot	unsigned long pgoff	unsigned long flags	-	mm/fremap.c:122
+9437440	set_tid_address	0x900100	int *tidptr	-	-	-	-	-	kernel/fork.c:1109
+9437441	timer_create	0x900101	const clockid_t which_clock	struct sigevent *timer_event_spec	timer_t *created_timer_id	-	-	-	kernel/posix-timers.c:535
+9437442	timer_settime	0x900102	timer_t timer_id	int flags	const struct itimerspec *new_setting	struct itimerspec *old_setting	-	-	kernel/posix-timers.c:819
+9437443	timer_gettime	0x900103	timer_t timer_id	struct itimerspec *setting	-	-	-	-	kernel/posix-timers.c:715
+9437444	timer_getoverrun	0x900104	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:751
+9437445	timer_delete	0x900105	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:882
+9437446	clock_settime	0x900106	const clockid_t which_clock	const struct timespec *tp	-	-	-	-	kernel/posix-timers.c:950
+9437447	clock_gettime	0x900107	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:965
+9437448	clock_getres	0x900108	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:1006
+9437449	clock_nanosleep	0x900109	const clockid_t which_clock	int flags	const struct timespec *rqtp	struct timespec *rmtp	-	-	kernel/posix-timers.c:1035
+9437450	statfs64	0x90010a	const char *pathname	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:175
+9437451	fstatfs64	0x90010b	unsigned int fd	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:196
+9437452	tgkill	0x90010c	pid_t tgid	pid_t pid	int sig	-	-	-	kernel/signal.c:2907
+9437453	utimes	0x90010d	char *filename	struct timeval *utimes	-	-	-	-	fs/utimes.c:221
+9437454	arm_fadvise64_64	0x90010e	int fd	int advice	loff_t offset	loff_t len	-	-	arch/arm/kernel/sys_arm.c:129
+9437455	pciconfig_iobase	-	-	-	-	-	-	-	Not implemented
+9437456	pciconfig_read	0x900110	unsigned long bus	unsigned long dfn	unsigned long off	unsigned long len	void *buf	-	drivers/pci/syscall.c:16
+9437457	pciconfig_write	0x900111	unsigned long bus	unsigned long dfn	unsigned long off	unsigned long len	void *buf	-	drivers/pci/syscall.c:86
+9437458	mq_open	0x900112	const char *u_name	int oflag	umode_t mode	struct mq_attr *u_attr	-	-	ipc/mqueue.c:803
+9437459	mq_unlink	0x900113	const char *u_name	-	-	-	-	-	ipc/mqueue.c:876
+9437460	mq_timedsend	0x900114	mqd_t mqdes	const char *u_msg_ptr	size_t msg_len	unsigned int msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:971
+9437461	mq_timedreceive	0x900115	mqd_t mqdes	char *u_msg_ptr	size_t msg_len	unsigned int *u_msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:1092
+9437462	mq_notify	0x900116	mqd_t mqdes	const struct sigevent *u_notification	-	-	-	-	ipc/mqueue.c:1201
+9437463	mq_getsetattr	0x900117	mqd_t mqdes	const struct mq_attr *u_mqstat	struct mq_attr *u_omqstat	-	-	-	ipc/mqueue.c:1333
+9437464	waitid	0x900118	int which	pid_t upid	struct siginfo *infop	int options	struct rusage *ru	-	kernel/exit.c:1763
+9437465	socket	0x900119	int family	int type	int protocol	-	-	-	net/socket.c:1324
+9437466	bind	0x90011a	int fd	struct sockaddr *umyaddr	int addrlen	-	-	-	net/socket.c:1446
+9437467	connect	0x90011b	int fd	struct sockaddr *uservaddr	int addrlen	-	-	-	net/socket.c:1600
+9437468	listen	0x90011c	int fd	int backlog	-	-	-	-	net/socket.c:1475
+9437469	accept	0x90011d	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	-	-	-	net/socket.c:1582
+9437470	getsockname	0x90011e	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1632
+9437471	getpeername	0x90011f	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1663
+9437472	socketpair	0x900120	int family	int type	int protocol	int *usockvec	-	-	net/socket.c:1365
+9437473	send	0x900121	int fd	void *buff	size_t len	unsigned int flags	-	-	net/socket.c:1742
+9437474	sendto	0x900122	int fd	void *buff	size_t len	unsigned int flags	struct sockaddr *addr	int addr_len	net/socket.c:1695
+9437475	recv	0x900123	int fd	void *ubuf	size_t size	unsigned int flags	-	-	net/socket.c:1799
+9437476	recvfrom	0x900124	int fd	void *ubuf	size_t size	unsigned int flags	struct sockaddr *addr	int *addr_len	net/socket.c:1754
+9437477	shutdown	0x900125	int fd	int how	-	-	-	-	net/socket.c:1874
+9437478	setsockopt	0x900126	int fd	int level	int optname	char *optval	int optlen	-	net/socket.c:1810
+9437479	getsockopt	0x900127	int fd	int level	int optname	char *optval	int *optlen	-	net/socket.c:1844
+9437480	sendmsg	0x900128	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2016
+9437481	recvmsg	0x900129	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2189
+9437482	semop	0x90012a	int semid	struct sembuf *tsops	unsigned nsops	-	-	-	ipc/sem.c:1548
+9437483	semget	0x90012b	key_t key	int nsems	int semflg	-	-	-	ipc/sem.c:367
+9437484	semctl	0x90012c	int semnum int cmd	union semun arg	-	-	-	-	ipc/sem.c:1121
+9437485	msgsnd	0x90012d	int msqid	struct msgbuf *msgp	size_t msgsz	int msgflg	-	-	ipc/msg.c:726
+9437486	msgrcv	0x90012e	int msqid	struct msgbuf *msgp	size_t msgsz	long msgtyp	int msgflg	-	ipc/msg.c:907
+9437487	msgget	0x90012f	key_t key	int msgflg	-	-	-	-	ipc/msg.c:312
+9437488	msgctl	0x900130	int msqid	int cmd	struct msqid_ds *buf	-	-	-	ipc/msg.c:469
+9437489	shmat	0x900131	int shmid	char *shmaddr	int shmflg	-	-	-	ipc/shm.c:1105
+9437490	shmdt	0x900132	char *shmaddr	-	-	-	-	-	ipc/shm.c:1121
+9437491	shmget	0x900133	key_t key	size_t size	int shmflg	-	-	-	ipc/shm.c:574
+9437492	shmctl	0x900134	int shmid	int cmd	struct shmid_ds *buf	-	-	-	ipc/shm.c:774
+9437493	add_key	0x900135	const char *_type	const char *_description	const void *_payload	size_t plen	key_serial_t ringid	-	security/keys/keyctl.c:54
+9437494	request_key	0x900136	const char *_type	const char *_description	const char *_callout_info	key_serial_t destringid	-	-	security/keys/keyctl.c:147
+9437495	keyctl	0x900137	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	security/keys/keyctl.c:1556
+9437496	semtimedop	0x900138	int semid	struct sembuf *tsops	unsigned nsops	const struct timespec *timeout	-	-	ipc/sem.c:1330
+9437497	vserver	-	-	-	-	-	-	-	Not implemented
+9437498	ioprio_set	0x90013a	int which	int who	int ioprio	-	-	-	fs/ioprio.c:61
+9437499	ioprio_get	0x90013b	int which	int who	-	-	-	-	fs/ioprio.c:176
+9437500	inotify_init	0x90013c	-	-	-	-	-	-	fs/notify/inotify/inotify_user.c:749
+9437501	inotify_add_watch	0x90013d	int fd	const char *pathname	u32 mask	-	-	-	fs/notify/inotify/inotify_user.c:754
+9437502	inotify_rm_watch	0x90013e	int fd	__s32 wd	-	-	-	-	fs/notify/inotify/inotify_user.c:795
+9437503	mbind	0x90013f	unsigned long start	unsigned long len	unsigned long mode	unsigned long *nmask	unsigned long maxnode	unsigned flags	mm/mempolicy.c:1263
+9437504	get_mempolicy	0x900140	int *policy	unsigned long *nmask	unsigned long maxnode	unsigned long addr	unsigned long flags	-	mm/mempolicy.c:1400
+9437505	set_mempolicy	0x900141	int mode	unsigned long *nmask	unsigned long maxnode	-	-	-	mm/mempolicy.c:1285
+9437506	openat	0x900142	int dfd	const char *filename	int flags	umode_t mode	-	-	fs/open.c:1059
+9437507	mkdirat	0x900143	int dfd	const char *pathname	umode_t mode	-	-	-	fs/namei.c:2723
+9437508	mknodat	0x900144	int dfd	const char *filename	umode_t mode	unsigned dev	-	-	fs/namei.c:2646
+9437509	fchownat	0x900145	int dfd	const char *filename	uid_t user	gid_t group	int flag	-	fs/open.c:559
+9437510	futimesat	0x900146	int dfd	const char *filename	struct timeval *utimes	-	-	-	fs/utimes.c:193
+9437511	fstatat64	0x900147	int dfd	const char *filename	struct stat64 *statbuf	int flag	-	-	fs/stat.c:407
+9437512	unlinkat	0x900148	int dfd	const char *pathname	int flag	-	-	-	fs/namei.c:2968
+9437513	renameat	0x900149	int olddfd	const char *oldname	int newdfd	const char *newname	-	-	fs/namei.c:3309
+9437514	linkat	0x90014a	int olddfd	const char *oldname	int newdfd	const char *newname	int flags	-	fs/namei.c:3097
+9437515	symlinkat	0x90014b	const char *oldname	int newdfd	const char *newname	-	-	-	fs/namei.c:3004
+9437516	readlinkat	0x90014c	int dfd	const char *pathname	char *buf	int bufsiz	-	-	fs/stat.c:293
+9437517	fchmodat	0x90014d	int dfd	const char *filename	umode_t mode	-	-	-	fs/open.c:486
+9437518	faccessat	0x90014e	int dfd	const char *filename	int mode	-	-	-	fs/open.c:299
+9437519	pselect6	0x90014f	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timespec *tsp	void *sig	fs/select.c:671
+9437520	ppoll	0x900150	struct pollfd *ufds	unsigned int nfds	struct timespec *tsp	const sigset_t *sigmask	size_t sigsetsize	-	fs/select.c:942
+9437521	unshare	0x900151	unsigned long unshare_flags	-	-	-	-	-	kernel/fork.c:1778
+9437522	set_robust_list	0x900152	struct robust_list_head *head	size_t len	-	-	-	-	kernel/futex.c:2422
+9437523	get_robust_list	0x900153	int pid	struct robust_list_head * *head_ptr	size_t *len_ptr	-	-	-	kernel/futex.c:2444
+9437524	splice	0x900154	int fd_in	loff_t *off_in	int fd_out	loff_t *off_out	size_t len	unsigned int flags	fs/splice.c:1689
+9437525	sync_file_range2	0x900155	unsigned int flags loff_t offset	loff_t nbytes	-	-	-	-	fs/sync.c:370
+9437526	tee	0x900156	int fdin	int fdout	size_t len	unsigned int flags	-	-	fs/splice.c:2025
+9437527	vmsplice	0x900157	int fd	const struct iovec *iov	unsigned long nr_segs	unsigned int flags	-	-	fs/splice.c:1663
+9437528	move_pages	0x900158	pid_t pid	unsigned long nr_pages	const void * *pages	const int *nodes	int *status	int flags	mm/migrate.c:1343
+9437529	getcpu	0x900159	unsigned *cpup	unsigned *nodep	struct getcpu_cache *unused	-	-	-	kernel/sys.c:2179
+9437530	epoll_pwait	0x90015a	int epfd	struct epoll_event *events	int maxevents	int timeout	const sigset_t *sigmask	size_t sigsetsize	fs/eventpoll.c:1860
+9437531	kexec_load	0x90015b	unsigned long entry	unsigned long nr_segments	struct kexec_segment *segments	unsigned long flags	-	-	kernel/kexec.c:940
+9437532	utimensat	0x90015c	int dfd	const char *filename	struct timespec *utimes	int flags	-	-	fs/utimes.c:175
+9437533	signalfd	0x90015d	int ufd	sigset_t *user_mask	size_t sizemask	-	-	-	fs/signalfd.c:292
+9437534	timerfd_create	0x90015e	int clockid	int flags	-	-	-	-	fs/timerfd.c:252
+9437535	eventfd	0x90015f	unsigned int count	-	-	-	-	-	fs/eventfd.c:431
+9437536	fallocate	0x900160	int mode loff_t offset	loff_t len	-	-	-	-	fs/open.c:272
+9437537	timerfd_settime	0x900161	int ufd	int flags	const struct itimerspec *utmr	struct itimerspec *otmr	-	-	fs/timerfd.c:283
+9437538	timerfd_gettime	0x900162	int ufd	struct itimerspec *otmr	-	-	-	-	fs/timerfd.c:344
+9437539	signalfd4	0x900163	int ufd	sigset_t *user_mask	size_t sizemask	int flags	-	-	fs/signalfd.c:237
+9437540	eventfd2	0x900164	unsigned int count	int flags	-	-	-	-	fs/eventfd.c:406
+9437541	epoll_create1	0x900165	int flags	-	-	-	-	-	fs/eventpoll.c:1625
+9437542	dup3	0x900166	unsigned int oldfd	unsigned int newfd	int flags	-	-	-	fs/fcntl.c:53
+9437543	pipe2	0x900167	int *fildes	int flags	-	-	-	-	fs/pipe.c:1133
+9437544	inotify_init1	0x900168	int flags	-	-	-	-	-	fs/notify/inotify/inotify_user.c:724
+9437545	preadv	0x900169	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:835
+9437546	pwritev	0x90016a	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:860
+9437547	rt_tgsigqueueinfo	0x90016b	pid_t tgid	pid_t pid	int sig	siginfo_t *uinfo	-	-	kernel/signal.c:2979
+9437548	perf_event_open	0x90016c	struct perf_event_attr *attr_uptr	pid_t pid	int cpu	int group_fd	unsigned long flags	-	kernel/events/core.c:6186
+9437549	recvmmsg	0x90016d	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	struct timespec *timeout	-	net/socket.c:2313
+9437550	accept4	0x90016e	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	int flags	-	-	net/socket.c:1508
+9437551	fanotify_init	0x90016f	unsigned int flags	unsigned int event_f_flags	-	-	-	-	fs/notify/fanotify/fanotify_user.c:679
+9437552	fanotify_mark	0x900170	unsigned int flags __u64 mask	int dfd const char *pathname	-	-	-	-	fs/notify/fanotify/fanotify_user.c:767
+9437553	prlimit64	0x900171	pid_t pid	unsigned int resource	const struct rlimit64 *new_rlim	struct rlimit64 *old_rlim	-	-	kernel/sys.c:1599
+9437554	name_to_handle_at	0x900172	int dfd	const char *name	struct file_handle *handle	int *mnt_id	int flag	-	fs/fhandle.c:92
+9437555	open_by_handle_at	0x900173	int mountdirfd	struct file_handle *handle	int flags	-	-	-	fs/fhandle.c:257
+9437556	clock_adjtime	0x900174	const clockid_t which_clock	struct timex *utx	-	-	-	-	kernel/posix-timers.c:983
+9437557	syncfs	0x900175	int fd	-	-	-	-	-	fs/sync.c:134
+9437558	sendmmsg	0x900176	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	-	-	net/socket.c:2091
+9437559	setns	0x900177	int fd	int nstype	-	-	-	-	kernel/nsproxy.c:235
+9437560	process_vm_readv	0x900178	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:398
+9437561	process_vm_writev	0x900179	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:405

--- a/addons/syscalls/tables/armthumb
+++ b/addons/syscalls/tables/armthumb
@@ -1,0 +1,346 @@
+#	Name	r7	r0	r1	r2	r3	r4	r5	Definition
+0	restart_syscall	0x00	-	-	-	-	-	-	kernel/signal.c:2501
+1	exit	0x01	int error_code	-	-	-	-	-	kernel/exit.c:1095
+2	fork	0x02	-	-	-	-	-	-	arch/arm/kernel/sys_arm.c:34
+3	read	0x03	unsigned int fd	char *buf	size_t count	-	-	-	fs/read_write.c:460
+4	write	0x04	unsigned int fd	const char *buf	size_t count	-	-	-	fs/read_write.c:477
+5	open	0x05	const char *filename	int flags	umode_t mode	-	-	-	fs/open.c:1046
+6	close	0x06	unsigned int fd	-	-	-	-	-	fs/open.c:1117
+8	creat	0x08	const char *pathname	umode_t mode	-	-	-	-	fs/open.c:1079
+9	link	0x09	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3152
+10	unlink	0x0a	const char *pathname	-	-	-	-	-	fs/namei.c:2979
+11	execve	0x0b	const char *filenamei	const char *const *argv	const char *const *envp	-	-	-	arch/arm/kernel/sys_arm.c:65
+12	chdir	0x0c	const char *filename	-	-	-	-	-	fs/open.c:375
+13	time	0x0d	time_t *tloc	-	-	-	-	-	kernel/time.c:62
+14	mknod	0x0e	const char *filename	umode_t mode	unsigned dev	-	-	-	fs/namei.c:2693
+15	chmod	0x0f	const char *filename	umode_t mode	-	-	-	-	fs/open.c:499
+16	lchown	0x10	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+19	lseek	0x13	unsigned int fd	off_t offset	unsigned int origin	-	-	-	fs/read_write.c:230
+20	getpid	0x14	-	-	-	-	-	-	kernel/timer.c:1413
+21	mount	0x15	char *dev_name	char *dir_name	char *type	unsigned long flags	void *data	-	fs/namespace.c:2362
+22	umount	0x16	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+23	setuid	0x17	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+24	getuid	0x18	-	-	-	-	-	-	kernel/timer.c:1435
+25	stime	0x19	time_t *tptr	-	-	-	-	-	kernel/time.c:81
+26	ptrace	0x1a	long request	long pid	unsigned long addr	unsigned long data	-	-	kernel/ptrace.c:857
+27	alarm	0x1b	unsigned int seconds	-	-	-	-	-	kernel/timer.c:1390
+29	pause	0x1d	-	-	-	-	-	-	kernel/signal.c:3245
+30	utime	0x1e	char *filename	struct utimbuf *times	-	-	-	-	fs/utimes.c:27
+33	access	0x21	const char *filename	int mode	-	-	-	-	fs/open.c:370
+34	nice	0x22	int increment	-	-	-	-	-	kernel/sched/core.c:4119
+36	sync	0x24	-	-	-	-	-	-	fs/sync.c:98
+37	kill	0x25	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2841
+38	rename	0x26	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3403
+39	mkdir	0x27	const char *pathname	umode_t mode	-	-	-	-	fs/namei.c:2751
+40	rmdir	0x28	const char *pathname	-	-	-	-	-	fs/namei.c:2870
+41	dup	0x29	unsigned int fildes	-	-	-	-	-	fs/fcntl.c:131
+42	pipe	0x2a	int *fildes	-	-	-	-	-	fs/pipe.c:1149
+43	times	0x2b	struct tms *tbuf	-	-	-	-	-	kernel/sys.c:1058
+45	brk	0x2d	unsigned long brk	-	-	-	-	-	mm/mmap.c:246
+46	setgid	0x2e	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+47	getgid	0x2f	-	-	-	-	-	-	kernel/timer.c:1447
+49	geteuid	0x31	-	-	-	-	-	-	kernel/timer.c:1441
+50	getegid	0x32	-	-	-	-	-	-	kernel/timer.c:1453
+51	acct	0x33	const char *name	-	-	-	-	-	kernel/acct.c:255
+52	umount2	0x34	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+54	ioctl	0x36	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/ioctl.c:604
+55	fcntl	0x37	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:442
+57	setpgid	0x39	pid_t pid	pid_t pgid	-	-	-	-	kernel/sys.c:1083
+60	umask	0x3c	int mask	-	-	-	-	-	kernel/sys.c:1782
+61	chroot	0x3d	const char *filename	-	-	-	-	-	fs/open.c:422
+62	ustat	0x3e	unsigned dev	struct ustat *ubuf	-	-	-	-	fs/statfs.c:222
+63	dup2	0x3f	unsigned int oldfd	unsigned int newfd	-	-	-	-	fs/fcntl.c:116
+64	getppid	0x40	-	-	-	-	-	-	kernel/timer.c:1424
+65	getpgrp	0x41	-	-	-	-	-	-	kernel/sys.c:1184
+66	setsid	0x42	-	-	-	-	-	-	kernel/sys.c:1219
+67	sigaction	0x43	int sig	const struct old_sigaction *act	struct old_sigaction *oact	-	-	-	arch/arm/kernel/signal.c:73
+70	setreuid	0x46	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+71	setregid	0x47	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+72	sigsuspend	0x48	int restart	unsigned long oldmask	old_sigset_t mask	-	-	-	arch/arm/kernel/signal.c:65
+73	sigpending	0x49	old_sigset_t *set	-	-	-	-	-	kernel/signal.c:3107
+74	sethostname	0x4a	char *name	int len	-	-	-	-	kernel/sys.c:1365
+75	setrlimit	0x4b	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1641
+76	getrlimit	0x4c	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+77	getrusage	0x4d	int who	struct rusage *ru	-	-	-	-	kernel/sys.c:1774
+78	gettimeofday	0x4e	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:101
+79	settimeofday	0x4f	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:179
+80	getgroups	0x50	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+81	setgroups	0x51	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+82	select	0x52	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+83	symlink	0x53	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3039
+85	readlink	0x55	const char *path	char *buf	int bufsiz	-	-	-	fs/stat.c:321
+86	uselib	0x56	const char *library	-	-	-	-	-	fs/exec.c:116
+87	swapon	0x57	const char *specialfile	int swap_flags	-	-	-	-	mm/swapfile.c:1996
+88	reboot	0x58	int magic1	int magic2	unsigned int cmd	void *arg	-	-	kernel/sys.c:432
+89	readdir	0x59	unsigned int fd	struct old_linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:105
+90	mmap	0x5a	struct mmap_arg_struct *arg	-	-	-	-	-	mm/mmap.c:1153
+91	munmap	0x5b	unsigned long addr	size_t len	-	-	-	-	mm/mmap.c:2141
+92	truncate	0x5c	const char *path	long length	-	-	-	-	fs/open.c:128
+93	ftruncate	0x5d	unsigned int fd	unsigned long length	-	-	-	-	fs/open.c:178
+94	fchmod	0x5e	unsigned int fd	umode_t mode	-	-	-	-	fs/open.c:472
+95	fchown	0x5f	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+96	getpriority	0x60	int which	int who	-	-	-	-	kernel/sys.c:241
+97	setpriority	0x61	int which	int who	int niceval	-	-	-	kernel/sys.c:172
+99	statfs	0x63	const char *pathname	struct statfs *buf	-	-	-	-	fs/statfs.c:166
+100	fstatfs	0x64	unsigned int fd	struct statfs *buf	-	-	-	-	fs/statfs.c:187
+102	socketcall	0x66	int call	unsigned long *args	-	-	-	-	net/socket.c:2355
+103	syslog	0x67	int type	char *buf	int len	-	-	-	kernel/printk.c:1195
+104	setitimer	0x68	int which	struct itimerval *value	struct itimerval *ovalue	-	-	-	kernel/itimer.c:278
+105	getitimer	0x69	int which	struct itimerval *value	-	-	-	-	kernel/itimer.c:103
+106	stat	0x6a	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:155
+107	lstat	0x6b	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:168
+108	fstat	0x6c	unsigned int fd	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:181
+111	vhangup	0x6f	-	-	-	-	-	-	fs/open.c:1156
+113	syscall	0x71	-	-	-	-	-	-	arch/arm/kernel/entry-common.S:502
+114	wait4	0x72	pid_t upid	int *stat_addr	int options	struct rusage *ru	-	-	kernel/exit.c:1834
+115	swapoff	0x73	const char *specialfile	-	-	-	-	-	mm/swapfile.c:1539
+116	sysinfo	0x74	struct sysinfo *info	-	-	-	-	-	kernel/timer.c:1641
+117	ipc	0x75	unsigned int call	int first	unsigned long second	unsigned long third	void *ptr	long fifth	ipc/syscall.c:16
+118	fsync	0x76	unsigned int fd	-	-	-	-	-	fs/sync.c:201
+119	sigreturn	0x77	-	-	-	-	-	-	arch/arm/kernel/signal.c:264
+120	clone	0x78	unsigned long clone_flags	unsigned long newsp	int *parent_tidptr	int tls_val	int *child_tidptr	-	arch/arm/kernel/sys_arm.c:47
+121	setdomainname	0x79	char *name	int len	-	-	-	-	kernel/sys.c:1416
+122	uname	0x7a	struct old_utsname *name	-	-	-	-	-	kernel/sys.c:1311
+124	adjtimex	0x7c	struct timex *txc_p	-	-	-	-	-	kernel/time.c:200
+125	mprotect	0x7d	unsigned long start	size_t len	unsigned long prot	-	-	-	mm/mprotect.c:232
+126	sigprocmask	0x7e	int how	old_sigset_t *nset	old_sigset_t *oset	-	-	-	kernel/signal.c:3125
+128	init_module	0x80	void *umod	unsigned long len	const char *uargs	-	-	-	kernel/module.c:3010
+129	delete_module	0x81	const char *name_user	unsigned int flags	-	-	-	-	kernel/module.c:768
+131	quotactl	0x83	unsigned int cmd	const char *special	qid_t id	void *addr	-	-	fs/quota/quota.c:346
+132	getpgid	0x84	pid_t pid	-	-	-	-	-	kernel/sys.c:1154
+133	fchdir	0x85	unsigned int fd	-	-	-	-	-	fs/open.c:396
+134	bdflush	0x86	int func	long data	-	-	-	-	fs/buffer.c:3130
+135	sysfs	0x87	int option	unsigned long arg1	unsigned long arg2	-	-	-	fs/filesystems.c:183
+136	personality	0x88	unsigned int personality	-	-	-	-	-	kernel/exec_domain.c:182
+138	setfsuid	0x8a	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+139	setfsgid	0x8b	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+140	_llseek	0x8c	unsigned int fd	unsigned long offset_high	unsigned long offset_low	loff_t *result	unsigned int origin	-	fs/read_write.c:254
+141	getdents	0x8d	unsigned int fd	struct linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:191
+142	_newselect	0x8e	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+143	flock	0x8f	unsigned int fd	unsigned int cmd	-	-	-	-	fs/locks.c:1636
+144	msync	0x90	unsigned long start	size_t len	int flags	-	-	-	mm/msync.c:31
+145	readv	0x91	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:787
+146	writev	0x92	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:808
+147	getsid	0x93	pid_t pid	-	-	-	-	-	kernel/sys.c:1191
+148	fdatasync	0x94	unsigned int fd	-	-	-	-	-	fs/sync.c:206
+149	_sysctl	0x95	struct __sysctl_args *args	-	-	-	-	-	kernel/sysctl_binary.c:1444
+150	mlock	0x96	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:482
+151	munlock	0x97	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:512
+152	mlockall	0x98	int flags	-	-	-	-	-	mm/mlock.c:549
+153	munlockall	0x99	-	-	-	-	-	-	mm/mlock.c:582
+154	sched_setparam	0x9a	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4477
+155	sched_getparam	0x9b	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4512
+156	sched_setscheduler	0x9c	pid_t pid	int policy	struct sched_param *param	-	-	-	kernel/sched/core.c:4462
+157	sched_getscheduler	0x9d	pid_t pid	-	-	-	-	-	kernel/sched/core.c:4486
+158	sched_yield	0x9e	-	-	-	-	-	-	kernel/sched/core.c:4711
+159	sched_get_priority_max	0x9f	int policy	-	-	-	-	-	kernel/sched/core.c:4935
+160	sched_get_priority_min	0xa0	int policy	-	-	-	-	-	kernel/sched/core.c:4960
+161	sched_rr_get_interval	0xa1	pid_t pid	struct timespec *interval	-	-	-	-	kernel/sched/core.c:4985
+162	nanosleep	0xa2	struct timespec *rqtp	struct timespec *rmtp	-	-	-	-	kernel/hrtimer.c:1621
+163	mremap	0xa3	unsigned long addr	unsigned long old_len	unsigned long new_len	unsigned long flags	unsigned long new_addr	-	mm/mremap.c:431
+164	setresuid	0xa4	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+165	getresuid	0xa5	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+168	poll	0xa8	struct pollfd *ufds	unsigned int nfds	int timeout_msecs	-	-	-	fs/select.c:908
+169	nfsservctl	-	-	-	-	-	-	-	Not implemented
+170	setresgid	0xaa	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+171	getresgid	0xab	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+172	prctl	0xac	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	kernel/sys.c:1999
+173	rt_sigreturn	0xad	-	-	-	-	-	-	arch/arm/kernel/signal.c:294
+174	rt_sigaction	0xae	int sig	const struct sigaction *act	struct sigaction *oact	size_t sigsetsize	-	-	kernel/signal.c:3174
+175	rt_sigprocmask	0xaf	int how	sigset_t *nset	sigset_t *oset	size_t sigsetsize	-	-	kernel/signal.c:2591
+176	rt_sigpending	0xb0	sigset_t *set	size_t sigsetsize	-	-	-	-	kernel/signal.c:2651
+177	rt_sigtimedwait	0xb1	const sigset_t *uthese	siginfo_t *uinfo	const struct timespec *uts	size_t sigsetsize	-	-	kernel/signal.c:2805
+178	rt_sigqueueinfo	0xb2	pid_t pid	int sig	siginfo_t *uinfo	-	-	-	kernel/signal.c:2938
+179	rt_sigsuspend	0xb3	sigset_t *unewset	size_t sigsetsize	-	-	-	-	kernel/signal.c:3274
+180	pread64	0xb4	char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:495
+181	pwrite64	0xb5	const char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:524
+182	chown	0xb6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+183	getcwd	0xb7	char *buf	unsigned long size	-	-	-	-	fs/dcache.c:2885
+184	capget	0xb8	cap_user_header_t header	cap_user_data_t dataptr	-	-	-	-	kernel/capability.c:158
+185	capset	0xb9	cap_user_header_t header	const cap_user_data_t data	-	-	-	-	kernel/capability.c:232
+186	sigaltstack	-	-	-	-	-	-	-	Not implemented
+187	sendfile	0xbb	int out_fd	int in_fd	off_t *offset	size_t count	-	-	fs/read_write.c:973
+190	vfork	0xbe	-	-	-	-	-	-	arch/arm/kernel/sys_arm.c:57
+191	ugetrlimit	0xbf	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+192	mmap2	0xc0	unsigned long addr	unsigned long len	unsigned long prot	unsigned long flags	unsigned long fd	unsigned long pgoff	mm/mmap.c:1105
+193	truncate64	0xc1	loff_t length	-	-	-	-	-	fs/open.c:188
+194	ftruncate64	0xc2	loff_t length	-	-	-	-	-	fs/open.c:200
+195	stat64	0xc3	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:372
+196	lstat64	0xc4	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:384
+197	fstat64	0xc5	unsigned long fd	struct stat64 *statbuf	-	-	-	-	fs/stat.c:396
+198	lchown32	0xc6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+199	getuid32	0xc7	-	-	-	-	-	-	kernel/timer.c:1435
+200	getgid32	0xc8	-	-	-	-	-	-	kernel/timer.c:1447
+201	geteuid32	0xc9	-	-	-	-	-	-	kernel/timer.c:1441
+202	getegid32	0xca	-	-	-	-	-	-	kernel/timer.c:1453
+203	setreuid32	0xcb	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+204	setregid32	0xcc	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+205	getgroups32	0xcd	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+206	setgroups32	0xce	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+207	fchown32	0xcf	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+208	setresuid32	0xd0	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+209	getresuid32	0xd1	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+210	setresgid32	0xd2	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+211	getresgid32	0xd3	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+212	chown32	0xd4	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+213	setuid32	0xd5	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+214	setgid32	0xd6	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+215	setfsuid32	0xd7	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+216	setfsgid32	0xd8	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+217	getdents64	0xd9	unsigned int fd	struct linux_dirent64 *dirent	unsigned int count	-	-	-	fs/readdir.c:272
+218	pivot_root	0xda	const char *new_root	const char *put_old	-	-	-	-	fs/namespace.c:2453
+219	mincore	0xdb	unsigned long start	size_t len	unsigned char *vec	-	-	-	mm/mincore.c:266
+220	madvise	0xdc	unsigned long start	size_t len_in	int behavior	-	-	-	mm/madvise.c:362
+221	fcntl64	0xdd	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:468
+224	gettid	0xe0	-	-	-	-	-	-	kernel/timer.c:1569
+225	readahead	0xe1	loff_t offset size_t count	-	-	-	-	-	mm/readahead.c:579
+226	setxattr	0xe2	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:361
+227	lsetxattr	0xe3	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:380
+228	fsetxattr	0xe4	int fd	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:399
+229	getxattr	0xe5	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:459
+230	lgetxattr	0xe6	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:473
+231	fgetxattr	0xe7	int fd	const char *name	void *value	size_t size	-	-	fs/xattr.c:487
+232	listxattr	0xe8	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:541
+233	llistxattr	0xe9	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:555
+234	flistxattr	0xea	int fd	char *list	size_t size	-	-	-	fs/xattr.c:569
+235	removexattr	0xeb	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:602
+236	lremovexattr	0xec	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:620
+237	fremovexattr	0xed	int fd	const char *name	-	-	-	-	fs/xattr.c:638
+238	tkill	0xee	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2923
+239	sendfile64	0xef	int out_fd	int in_fd	loff_t *offset	size_t count	-	-	fs/read_write.c:992
+240	futex	0xf0	u32 *uaddr	int op	u32 val	struct timespec *utime	u32 *uaddr2	u32 val3	kernel/futex.c:2680
+241	sched_setaffinity	0xf1	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4626
+242	sched_getaffinity	0xf2	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4677
+243	io_setup	0xf3	unsigned nr_events	aio_context_t *ctxp	-	-	-	-	fs/aio.c:1298
+244	io_destroy	0xf4	aio_context_t ctx	-	-	-	-	-	fs/aio.c:1334
+245	io_getevents	0xf5	aio_context_t ctx_id	long min_nr	long nr	struct io_event *events	struct timespec *timeout	-	fs/aio.c:1844
+246	io_submit	0xf6	aio_context_t ctx_id	long nr	struct iocb * *iocbpp	-	-	-	fs/aio.c:1746
+247	io_cancel	0xf7	aio_context_t ctx_id	struct iocb *iocb	struct io_event *result	-	-	-	fs/aio.c:1781
+248	exit_group	0xf8	int error_code	-	-	-	-	-	kernel/exit.c:1136
+249	lookup_dcookie	0xf9	char *buf size_t len	-	-	-	-	-	fs/dcookies.c:148
+250	epoll_create	0xfa	int size	-	-	-	-	-	fs/eventpoll.c:1668
+251	epoll_ctl	0xfb	int epfd	int op	int fd	struct epoll_event *event	-	-	fs/eventpoll.c:1681
+252	epoll_wait	0xfc	int epfd	struct epoll_event *events	int maxevents	int timeout	-	-	fs/eventpoll.c:1809
+253	remap_file_pages	0xfd	unsigned long start	unsigned long size	unsigned long prot	unsigned long pgoff	unsigned long flags	-	mm/fremap.c:122
+256	set_tid_address	0x100	int *tidptr	-	-	-	-	-	kernel/fork.c:1109
+257	timer_create	0x101	const clockid_t which_clock	struct sigevent *timer_event_spec	timer_t *created_timer_id	-	-	-	kernel/posix-timers.c:535
+258	timer_settime	0x102	timer_t timer_id	int flags	const struct itimerspec *new_setting	struct itimerspec *old_setting	-	-	kernel/posix-timers.c:819
+259	timer_gettime	0x103	timer_t timer_id	struct itimerspec *setting	-	-	-	-	kernel/posix-timers.c:715
+260	timer_getoverrun	0x104	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:751
+261	timer_delete	0x105	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:882
+262	clock_settime	0x106	const clockid_t which_clock	const struct timespec *tp	-	-	-	-	kernel/posix-timers.c:950
+263	clock_gettime	0x107	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:965
+264	clock_getres	0x108	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:1006
+265	clock_nanosleep	0x109	const clockid_t which_clock	int flags	const struct timespec *rqtp	struct timespec *rmtp	-	-	kernel/posix-timers.c:1035
+266	statfs64	0x10a	const char *pathname	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:175
+267	fstatfs64	0x10b	unsigned int fd	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:196
+268	tgkill	0x10c	pid_t tgid	pid_t pid	int sig	-	-	-	kernel/signal.c:2907
+269	utimes	0x10d	char *filename	struct timeval *utimes	-	-	-	-	fs/utimes.c:221
+270	arm_fadvise64_64	0x10e	int fd	int advice	loff_t offset	loff_t len	-	-	arch/arm/kernel/sys_arm.c:129
+271	pciconfig_iobase	-	-	-	-	-	-	-	Not implemented
+272	pciconfig_read	0x110	unsigned long bus	unsigned long dfn	unsigned long off	unsigned long len	void *buf	-	drivers/pci/syscall.c:16
+273	pciconfig_write	0x111	unsigned long bus	unsigned long dfn	unsigned long off	unsigned long len	void *buf	-	drivers/pci/syscall.c:86
+274	mq_open	0x112	const char *u_name	int oflag	umode_t mode	struct mq_attr *u_attr	-	-	ipc/mqueue.c:803
+275	mq_unlink	0x113	const char *u_name	-	-	-	-	-	ipc/mqueue.c:876
+276	mq_timedsend	0x114	mqd_t mqdes	const char *u_msg_ptr	size_t msg_len	unsigned int msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:971
+277	mq_timedreceive	0x115	mqd_t mqdes	char *u_msg_ptr	size_t msg_len	unsigned int *u_msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:1092
+278	mq_notify	0x116	mqd_t mqdes	const struct sigevent *u_notification	-	-	-	-	ipc/mqueue.c:1201
+279	mq_getsetattr	0x117	mqd_t mqdes	const struct mq_attr *u_mqstat	struct mq_attr *u_omqstat	-	-	-	ipc/mqueue.c:1333
+280	waitid	0x118	int which	pid_t upid	struct siginfo *infop	int options	struct rusage *ru	-	kernel/exit.c:1763
+281	socket	0x119	int family	int type	int protocol	-	-	-	net/socket.c:1324
+282	bind	0x11a	int fd	struct sockaddr *umyaddr	int addrlen	-	-	-	net/socket.c:1446
+283	connect	0x11b	int fd	struct sockaddr *uservaddr	int addrlen	-	-	-	net/socket.c:1600
+284	listen	0x11c	int fd	int backlog	-	-	-	-	net/socket.c:1475
+285	accept	0x11d	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	-	-	-	net/socket.c:1582
+286	getsockname	0x11e	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1632
+287	getpeername	0x11f	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1663
+288	socketpair	0x120	int family	int type	int protocol	int *usockvec	-	-	net/socket.c:1365
+289	send	0x121	int fd	void *buff	size_t len	unsigned int flags	-	-	net/socket.c:1742
+290	sendto	0x122	int fd	void *buff	size_t len	unsigned int flags	struct sockaddr *addr	int addr_len	net/socket.c:1695
+291	recv	0x123	int fd	void *ubuf	size_t size	unsigned int flags	-	-	net/socket.c:1799
+292	recvfrom	0x124	int fd	void *ubuf	size_t size	unsigned int flags	struct sockaddr *addr	int *addr_len	net/socket.c:1754
+293	shutdown	0x125	int fd	int how	-	-	-	-	net/socket.c:1874
+294	setsockopt	0x126	int fd	int level	int optname	char *optval	int optlen	-	net/socket.c:1810
+295	getsockopt	0x127	int fd	int level	int optname	char *optval	int *optlen	-	net/socket.c:1844
+296	sendmsg	0x128	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2016
+297	recvmsg	0x129	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2189
+298	semop	0x12a	int semid	struct sembuf *tsops	unsigned nsops	-	-	-	ipc/sem.c:1548
+299	semget	0x12b	key_t key	int nsems	int semflg	-	-	-	ipc/sem.c:367
+300	semctl	0x12c	int semnum int cmd	union semun arg	-	-	-	-	ipc/sem.c:1121
+301	msgsnd	0x12d	int msqid	struct msgbuf *msgp	size_t msgsz	int msgflg	-	-	ipc/msg.c:726
+302	msgrcv	0x12e	int msqid	struct msgbuf *msgp	size_t msgsz	long msgtyp	int msgflg	-	ipc/msg.c:907
+303	msgget	0x12f	key_t key	int msgflg	-	-	-	-	ipc/msg.c:312
+304	msgctl	0x130	int msqid	int cmd	struct msqid_ds *buf	-	-	-	ipc/msg.c:469
+305	shmat	0x131	int shmid	char *shmaddr	int shmflg	-	-	-	ipc/shm.c:1105
+306	shmdt	0x132	char *shmaddr	-	-	-	-	-	ipc/shm.c:1121
+307	shmget	0x133	key_t key	size_t size	int shmflg	-	-	-	ipc/shm.c:574
+308	shmctl	0x134	int shmid	int cmd	struct shmid_ds *buf	-	-	-	ipc/shm.c:774
+309	add_key	0x135	const char *_type	const char *_description	const void *_payload	size_t plen	key_serial_t ringid	-	security/keys/keyctl.c:54
+310	request_key	0x136	const char *_type	const char *_description	const char *_callout_info	key_serial_t destringid	-	-	security/keys/keyctl.c:147
+311	keyctl	0x137	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	security/keys/keyctl.c:1556
+312	semtimedop	0x138	int semid	struct sembuf *tsops	unsigned nsops	const struct timespec *timeout	-	-	ipc/sem.c:1330
+313	vserver	-	-	-	-	-	-	-	Not implemented
+314	ioprio_set	0x13a	int which	int who	int ioprio	-	-	-	fs/ioprio.c:61
+315	ioprio_get	0x13b	int which	int who	-	-	-	-	fs/ioprio.c:176
+316	inotify_init	0x13c	-	-	-	-	-	-	fs/notify/inotify/inotify_user.c:749
+317	inotify_add_watch	0x13d	int fd	const char *pathname	u32 mask	-	-	-	fs/notify/inotify/inotify_user.c:754
+318	inotify_rm_watch	0x13e	int fd	__s32 wd	-	-	-	-	fs/notify/inotify/inotify_user.c:795
+319	mbind	0x13f	unsigned long start	unsigned long len	unsigned long mode	unsigned long *nmask	unsigned long maxnode	unsigned flags	mm/mempolicy.c:1263
+320	get_mempolicy	0x140	int *policy	unsigned long *nmask	unsigned long maxnode	unsigned long addr	unsigned long flags	-	mm/mempolicy.c:1400
+321	set_mempolicy	0x141	int mode	unsigned long *nmask	unsigned long maxnode	-	-	-	mm/mempolicy.c:1285
+322	openat	0x142	int dfd	const char *filename	int flags	umode_t mode	-	-	fs/open.c:1059
+323	mkdirat	0x143	int dfd	const char *pathname	umode_t mode	-	-	-	fs/namei.c:2723
+324	mknodat	0x144	int dfd	const char *filename	umode_t mode	unsigned dev	-	-	fs/namei.c:2646
+325	fchownat	0x145	int dfd	const char *filename	uid_t user	gid_t group	int flag	-	fs/open.c:559
+326	futimesat	0x146	int dfd	const char *filename	struct timeval *utimes	-	-	-	fs/utimes.c:193
+327	fstatat64	0x147	int dfd	const char *filename	struct stat64 *statbuf	int flag	-	-	fs/stat.c:407
+328	unlinkat	0x148	int dfd	const char *pathname	int flag	-	-	-	fs/namei.c:2968
+329	renameat	0x149	int olddfd	const char *oldname	int newdfd	const char *newname	-	-	fs/namei.c:3309
+330	linkat	0x14a	int olddfd	const char *oldname	int newdfd	const char *newname	int flags	-	fs/namei.c:3097
+331	symlinkat	0x14b	const char *oldname	int newdfd	const char *newname	-	-	-	fs/namei.c:3004
+332	readlinkat	0x14c	int dfd	const char *pathname	char *buf	int bufsiz	-	-	fs/stat.c:293
+333	fchmodat	0x14d	int dfd	const char *filename	umode_t mode	-	-	-	fs/open.c:486
+334	faccessat	0x14e	int dfd	const char *filename	int mode	-	-	-	fs/open.c:299
+335	pselect6	0x14f	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timespec *tsp	void *sig	fs/select.c:671
+336	ppoll	0x150	struct pollfd *ufds	unsigned int nfds	struct timespec *tsp	const sigset_t *sigmask	size_t sigsetsize	-	fs/select.c:942
+337	unshare	0x151	unsigned long unshare_flags	-	-	-	-	-	kernel/fork.c:1778
+338	set_robust_list	0x152	struct robust_list_head *head	size_t len	-	-	-	-	kernel/futex.c:2422
+339	get_robust_list	0x153	int pid	struct robust_list_head * *head_ptr	size_t *len_ptr	-	-	-	kernel/futex.c:2444
+340	splice	0x154	int fd_in	loff_t *off_in	int fd_out	loff_t *off_out	size_t len	unsigned int flags	fs/splice.c:1689
+341	sync_file_range2	0x155	unsigned int flags loff_t offset	loff_t nbytes	-	-	-	-	fs/sync.c:370
+342	tee	0x156	int fdin	int fdout	size_t len	unsigned int flags	-	-	fs/splice.c:2025
+343	vmsplice	0x157	int fd	const struct iovec *iov	unsigned long nr_segs	unsigned int flags	-	-	fs/splice.c:1663
+344	move_pages	0x158	pid_t pid	unsigned long nr_pages	const void * *pages	const int *nodes	int *status	int flags	mm/migrate.c:1343
+345	getcpu	0x159	unsigned *cpup	unsigned *nodep	struct getcpu_cache *unused	-	-	-	kernel/sys.c:2179
+346	epoll_pwait	0x15a	int epfd	struct epoll_event *events	int maxevents	int timeout	const sigset_t *sigmask	size_t sigsetsize	fs/eventpoll.c:1860
+347	kexec_load	0x15b	unsigned long entry	unsigned long nr_segments	struct kexec_segment *segments	unsigned long flags	-	-	kernel/kexec.c:940
+348	utimensat	0x15c	int dfd	const char *filename	struct timespec *utimes	int flags	-	-	fs/utimes.c:175
+349	signalfd	0x15d	int ufd	sigset_t *user_mask	size_t sizemask	-	-	-	fs/signalfd.c:292
+350	timerfd_create	0x15e	int clockid	int flags	-	-	-	-	fs/timerfd.c:252
+351	eventfd	0x15f	unsigned int count	-	-	-	-	-	fs/eventfd.c:431
+352	fallocate	0x160	int mode loff_t offset	loff_t len	-	-	-	-	fs/open.c:272
+353	timerfd_settime	0x161	int ufd	int flags	const struct itimerspec *utmr	struct itimerspec *otmr	-	-	fs/timerfd.c:283
+354	timerfd_gettime	0x162	int ufd	struct itimerspec *otmr	-	-	-	-	fs/timerfd.c:344
+355	signalfd4	0x163	int ufd	sigset_t *user_mask	size_t sizemask	int flags	-	-	fs/signalfd.c:237
+356	eventfd2	0x164	unsigned int count	int flags	-	-	-	-	fs/eventfd.c:406
+357	epoll_create1	0x165	int flags	-	-	-	-	-	fs/eventpoll.c:1625
+358	dup3	0x166	unsigned int oldfd	unsigned int newfd	int flags	-	-	-	fs/fcntl.c:53
+359	pipe2	0x167	int *fildes	int flags	-	-	-	-	fs/pipe.c:1133
+360	inotify_init1	0x168	int flags	-	-	-	-	-	fs/notify/inotify/inotify_user.c:724
+361	preadv	0x169	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:835
+362	pwritev	0x16a	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:860
+363	rt_tgsigqueueinfo	0x16b	pid_t tgid	pid_t pid	int sig	siginfo_t *uinfo	-	-	kernel/signal.c:2979
+364	perf_event_open	0x16c	struct perf_event_attr *attr_uptr	pid_t pid	int cpu	int group_fd	unsigned long flags	-	kernel/events/core.c:6186
+365	recvmmsg	0x16d	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	struct timespec *timeout	-	net/socket.c:2313
+366	accept4	0x16e	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	int flags	-	-	net/socket.c:1508
+367	fanotify_init	0x16f	unsigned int flags	unsigned int event_f_flags	-	-	-	-	fs/notify/fanotify/fanotify_user.c:679
+368	fanotify_mark	0x170	unsigned int flags __u64 mask	int dfd const char *pathname	-	-	-	-	fs/notify/fanotify/fanotify_user.c:767
+369	prlimit64	0x171	pid_t pid	unsigned int resource	const struct rlimit64 *new_rlim	struct rlimit64 *old_rlim	-	-	kernel/sys.c:1599
+370	name_to_handle_at	0x172	int dfd	const char *name	struct file_handle *handle	int *mnt_id	int flag	-	fs/fhandle.c:92
+371	open_by_handle_at	0x173	int mountdirfd	struct file_handle *handle	int flags	-	-	-	fs/fhandle.c:257
+372	clock_adjtime	0x174	const clockid_t which_clock	struct timex *utx	-	-	-	-	kernel/posix-timers.c:983
+373	syncfs	0x175	int fd	-	-	-	-	-	fs/sync.c:134
+374	sendmmsg	0x176	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	-	-	net/socket.c:2091
+375	setns	0x177	int fd	int nstype	-	-	-	-	kernel/nsproxy.c:235
+376	process_vm_readv	0x178	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:398
+377	process_vm_writev	0x179	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:405

--- a/addons/syscalls/tables/x64
+++ b/addons/syscalls/tables/x64
@@ -1,0 +1,314 @@
+#	Name	rax	rdi	rsi	rdx	rcx	r8	r9	Definition
+0	read	0x00	unsigned int fd	char *buf	size_t count	-	-	-	fs/read_write.c:460
+1	write	0x01	unsigned int fd	const char *buf	size_t count	-	-	-	fs/read_write.c:477
+2	open	0x02	const char *filename	int flags	umode_t mode	-	-	-	fs/open.c:1046
+3	close	0x03	unsigned int fd	-	-	-	-	-	fs/open.c:1117
+4	stat	0x04	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:155
+5	fstat	0x05	unsigned int fd	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:181
+6	lstat	0x06	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:168
+7	poll	0x07	struct pollfd *ufds	unsigned int nfds	int timeout_msecs	-	-	-	fs/select.c:908
+8	lseek	0x08	unsigned int fd	off_t offset	unsigned int origin	-	-	-	fs/read_write.c:230
+9	mmap	0x09	unsigned long addr	unsigned long len	unsigned long prot	unsigned long flags	unsigned long fd	unsigned long off	arch/x86/kernel/sys_x86_64.c:84
+10	mprotect	0x0a	unsigned long start	size_t len	unsigned long prot	-	-	-	mm/mprotect.c:232
+11	munmap	0x0b	unsigned long addr	size_t len	-	-	-	-	mm/mmap.c:2141
+12	brk	0x0c	unsigned long brk	-	-	-	-	-	mm/mmap.c:246
+13	rt_sigaction	0x0d	int sig	const struct sigaction *act	struct sigaction *oact	size_t sigsetsize	-	-	kernel/signal.c:3174
+14	rt_sigprocmask	0x0e	int how	sigset_t *nset	sigset_t *oset	size_t sigsetsize	-	-	kernel/signal.c:2591
+15	rt_sigreturn	0x0f	-	-	-	-	-	-	arch/x86/kernel/signal.c:571
+16	ioctl	0x10	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/ioctl.c:604
+17	pread64	0x11	char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:495
+18	pwrite64	0x12	const char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:524
+19	readv	0x13	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:787
+20	writev	0x14	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:808
+21	access	0x15	const char *filename	int mode	-	-	-	-	fs/open.c:370
+22	pipe	0x16	int *fildes	-	-	-	-	-	fs/pipe.c:1149
+23	select	0x17	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+24	sched_yield	0x18	-	-	-	-	-	-	kernel/sched/core.c:4711
+25	mremap	0x19	unsigned long addr	unsigned long old_len	unsigned long new_len	unsigned long flags	unsigned long new_addr	-	mm/mremap.c:431
+26	msync	0x1a	unsigned long start	size_t len	int flags	-	-	-	mm/msync.c:31
+27	mincore	0x1b	unsigned long start	size_t len	unsigned char *vec	-	-	-	mm/mincore.c:266
+28	madvise	0x1c	unsigned long start	size_t len_in	int behavior	-	-	-	mm/madvise.c:362
+29	shmget	0x1d	key_t key	size_t size	int shmflg	-	-	-	ipc/shm.c:574
+30	shmat	0x1e	int shmid	char *shmaddr	int shmflg	-	-	-	ipc/shm.c:1105
+31	shmctl	0x1f	int shmid	int cmd	struct shmid_ds *buf	-	-	-	ipc/shm.c:774
+32	dup	0x20	unsigned int fildes	-	-	-	-	-	fs/fcntl.c:131
+33	dup2	0x21	unsigned int oldfd	unsigned int newfd	-	-	-	-	fs/fcntl.c:116
+34	pause	0x22	-	-	-	-	-	-	kernel/signal.c:3245
+35	nanosleep	0x23	struct timespec *rqtp	struct timespec *rmtp	-	-	-	-	kernel/hrtimer.c:1621
+36	getitimer	0x24	int which	struct itimerval *value	-	-	-	-	kernel/itimer.c:103
+37	alarm	0x25	unsigned int seconds	-	-	-	-	-	kernel/timer.c:1390
+38	setitimer	0x26	int which	struct itimerval *value	struct itimerval *ovalue	-	-	-	kernel/itimer.c:278
+39	getpid	0x27	-	-	-	-	-	-	kernel/timer.c:1413
+40	sendfile	0x28	int out_fd	int in_fd	off_t *offset	size_t count	-	-	fs/read_write.c:973
+41	socket	0x29	int family	int type	int protocol	-	-	-	net/socket.c:1324
+42	connect	0x2a	int fd	struct sockaddr *uservaddr	int addrlen	-	-	-	net/socket.c:1600
+43	accept	0x2b	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	-	-	-	net/socket.c:1582
+44	sendto	0x2c	int fd	void *buff	size_t len	unsigned int flags	struct sockaddr *addr	int addr_len	net/socket.c:1695
+45	recvfrom	0x2d	int fd	void *ubuf	size_t size	unsigned int flags	struct sockaddr *addr	int *addr_len	net/socket.c:1754
+46	sendmsg	0x2e	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2016
+47	recvmsg	0x2f	int fd	struct msghdr *msg	unsigned int flags	-	-	-	net/socket.c:2189
+48	shutdown	0x30	int fd	int how	-	-	-	-	net/socket.c:1874
+49	bind	0x31	int fd	struct sockaddr *umyaddr	int addrlen	-	-	-	net/socket.c:1446
+50	listen	0x32	int fd	int backlog	-	-	-	-	net/socket.c:1475
+51	getsockname	0x33	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1632
+52	getpeername	0x34	int fd	struct sockaddr *usockaddr	int *usockaddr_len	-	-	-	net/socket.c:1663
+53	socketpair	0x35	int family	int type	int protocol	int *usockvec	-	-	net/socket.c:1365
+54	setsockopt	0x36	int fd	int level	int optname	char *optval	int optlen	-	net/socket.c:1810
+55	getsockopt	0x37	int fd	int level	int optname	char *optval	int *optlen	-	net/socket.c:1844
+56	clone	0x38	unsigned long clone_flags	unsigned long newsp	void *parent_tid	void *child_tid	-	-	arch/x86/kernel/process.c:293
+57	fork	0x39	-	-	-	-	-	-	arch/x86/kernel/process.c:271
+58	vfork	0x3a	-	-	-	-	-	-	arch/x86/kernel/process.c:286
+59	execve	0x3b	const char *name	const char *const *argv	const char *const *envp	-	-	-	arch/x86/kernel/process.c:342
+60	exit	0x3c	int error_code	-	-	-	-	-	kernel/exit.c:1095
+61	wait4	0x3d	pid_t upid	int *stat_addr	int options	struct rusage *ru	-	-	kernel/exit.c:1834
+62	kill	0x3e	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2841
+63	uname	0x3f	struct old_utsname *name	-	-	-	-	-	kernel/sys.c:1311
+64	semget	0x40	key_t key	int nsems	int semflg	-	-	-	ipc/sem.c:367
+65	semop	0x41	int semid	struct sembuf *tsops	unsigned nsops	-	-	-	ipc/sem.c:1548
+66	semctl	0x42	int semnum int cmd	union semun arg	-	-	-	-	ipc/sem.c:1121
+67	shmdt	0x43	char *shmaddr	-	-	-	-	-	ipc/shm.c:1121
+68	msgget	0x44	key_t key	int msgflg	-	-	-	-	ipc/msg.c:312
+69	msgsnd	0x45	int msqid	struct msgbuf *msgp	size_t msgsz	int msgflg	-	-	ipc/msg.c:726
+70	msgrcv	0x46	int msqid	struct msgbuf *msgp	size_t msgsz	long msgtyp	int msgflg	-	ipc/msg.c:907
+71	msgctl	0x47	int msqid	int cmd	struct msqid_ds *buf	-	-	-	ipc/msg.c:469
+72	fcntl	0x48	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:442
+73	flock	0x49	unsigned int fd	unsigned int cmd	-	-	-	-	fs/locks.c:1636
+74	fsync	0x4a	unsigned int fd	-	-	-	-	-	fs/sync.c:201
+75	fdatasync	0x4b	unsigned int fd	-	-	-	-	-	fs/sync.c:206
+76	truncate	0x4c	const char *path	long length	-	-	-	-	fs/open.c:128
+77	ftruncate	0x4d	unsigned int fd	unsigned long length	-	-	-	-	fs/open.c:178
+78	getdents	0x4e	unsigned int fd	struct linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:191
+79	getcwd	0x4f	char *buf	unsigned long size	-	-	-	-	fs/dcache.c:2885
+80	chdir	0x50	const char *filename	-	-	-	-	-	fs/open.c:375
+81	fchdir	0x51	unsigned int fd	-	-	-	-	-	fs/open.c:396
+82	rename	0x52	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3403
+83	mkdir	0x53	const char *pathname	umode_t mode	-	-	-	-	fs/namei.c:2751
+84	rmdir	0x54	const char *pathname	-	-	-	-	-	fs/namei.c:2870
+85	creat	0x55	const char *pathname	umode_t mode	-	-	-	-	fs/open.c:1079
+86	link	0x56	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3152
+87	unlink	0x57	const char *pathname	-	-	-	-	-	fs/namei.c:2979
+88	symlink	0x58	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3039
+89	readlink	0x59	const char *path	char *buf	int bufsiz	-	-	-	fs/stat.c:321
+90	chmod	0x5a	const char *filename	umode_t mode	-	-	-	-	fs/open.c:499
+91	fchmod	0x5b	unsigned int fd	umode_t mode	-	-	-	-	fs/open.c:472
+92	chown	0x5c	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+93	fchown	0x5d	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+94	lchown	0x5e	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+95	umask	0x5f	int mask	-	-	-	-	-	kernel/sys.c:1782
+96	gettimeofday	0x60	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:101
+97	getrlimit	0x61	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+98	getrusage	0x62	int who	struct rusage *ru	-	-	-	-	kernel/sys.c:1774
+99	sysinfo	0x63	struct sysinfo *info	-	-	-	-	-	kernel/timer.c:1641
+100	times	0x64	struct tms *tbuf	-	-	-	-	-	kernel/sys.c:1058
+101	ptrace	0x65	long request	long pid	unsigned long addr	unsigned long data	-	-	kernel/ptrace.c:857
+102	getuid	0x66	-	-	-	-	-	-	kernel/timer.c:1435
+103	syslog	0x67	int type	char *buf	int len	-	-	-	kernel/printk.c:1195
+104	getgid	0x68	-	-	-	-	-	-	kernel/timer.c:1447
+105	setuid	0x69	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+106	setgid	0x6a	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+107	geteuid	0x6b	-	-	-	-	-	-	kernel/timer.c:1441
+108	getegid	0x6c	-	-	-	-	-	-	kernel/timer.c:1453
+109	setpgid	0x6d	pid_t pid	pid_t pgid	-	-	-	-	kernel/sys.c:1083
+110	getppid	0x6e	-	-	-	-	-	-	kernel/timer.c:1424
+111	getpgrp	0x6f	-	-	-	-	-	-	kernel/sys.c:1184
+112	setsid	0x70	-	-	-	-	-	-	kernel/sys.c:1219
+113	setreuid	0x71	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+114	setregid	0x72	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+115	getgroups	0x73	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+116	setgroups	0x74	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+117	setresuid	0x75	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+118	getresuid	0x76	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+119	setresgid	0x77	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+120	getresgid	0x78	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+121	getpgid	0x79	pid_t pid	-	-	-	-	-	kernel/sys.c:1154
+122	setfsuid	0x7a	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+123	setfsgid	0x7b	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+124	getsid	0x7c	pid_t pid	-	-	-	-	-	kernel/sys.c:1191
+125	capget	0x7d	cap_user_header_t header	cap_user_data_t dataptr	-	-	-	-	kernel/capability.c:158
+126	capset	0x7e	cap_user_header_t header	const cap_user_data_t data	-	-	-	-	kernel/capability.c:232
+127	rt_sigpending	0x7f	sigset_t *set	size_t sigsetsize	-	-	-	-	kernel/signal.c:2651
+128	rt_sigtimedwait	0x80	const sigset_t *uthese	siginfo_t *uinfo	const struct timespec *uts	size_t sigsetsize	-	-	kernel/signal.c:2805
+129	rt_sigqueueinfo	0x81	pid_t pid	int sig	siginfo_t *uinfo	-	-	-	kernel/signal.c:2938
+130	rt_sigsuspend	0x82	sigset_t *unewset	size_t sigsetsize	-	-	-	-	kernel/signal.c:3274
+131	sigaltstack	0x83	const stack_t *uss	stack_t *uoss	-	-	-	-	arch/x86/kernel/signal.c:533
+132	utime	0x84	char *filename	struct utimbuf *times	-	-	-	-	fs/utimes.c:27
+133	mknod	0x85	const char *filename	umode_t mode	unsigned dev	-	-	-	fs/namei.c:2693
+134	uselib	-	-	-	-	-	-	-	Not implemented
+135	personality	0x87	unsigned int personality	-	-	-	-	-	kernel/exec_domain.c:182
+136	ustat	0x88	unsigned dev	struct ustat *ubuf	-	-	-	-	fs/statfs.c:222
+137	statfs	0x89	const char *pathname	struct statfs *buf	-	-	-	-	fs/statfs.c:166
+138	fstatfs	0x8a	unsigned int fd	struct statfs *buf	-	-	-	-	fs/statfs.c:187
+139	sysfs	0x8b	int option	unsigned long arg1	unsigned long arg2	-	-	-	fs/filesystems.c:183
+140	getpriority	0x8c	int which	int who	-	-	-	-	kernel/sys.c:241
+141	setpriority	0x8d	int which	int who	int niceval	-	-	-	kernel/sys.c:172
+142	sched_setparam	0x8e	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4477
+143	sched_getparam	0x8f	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4512
+144	sched_setscheduler	0x90	pid_t pid	int policy	struct sched_param *param	-	-	-	kernel/sched/core.c:4462
+145	sched_getscheduler	0x91	pid_t pid	-	-	-	-	-	kernel/sched/core.c:4486
+146	sched_get_priority_max	0x92	int policy	-	-	-	-	-	kernel/sched/core.c:4935
+147	sched_get_priority_min	0x93	int policy	-	-	-	-	-	kernel/sched/core.c:4960
+148	sched_rr_get_interval	0x94	pid_t pid	struct timespec *interval	-	-	-	-	kernel/sched/core.c:4985
+149	mlock	0x95	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:482
+150	munlock	0x96	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:512
+151	mlockall	0x97	int flags	-	-	-	-	-	mm/mlock.c:549
+152	munlockall	0x98	-	-	-	-	-	-	mm/mlock.c:582
+153	vhangup	0x99	-	-	-	-	-	-	fs/open.c:1156
+154	modify_ldt	0x9a	int func	void *ptr	unsigned long bytecount	-	-	-	arch/x86/kernel/ldt.c:247
+155	pivot_root	0x9b	const char *new_root	const char *put_old	-	-	-	-	fs/namespace.c:2453
+156	_sysctl	0x9c	struct __sysctl_args *args	-	-	-	-	-	kernel/sysctl_binary.c:1444
+157	prctl	0x9d	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	kernel/sys.c:1999
+158	arch_prctl	0x9e	int code	unsigned long addr	-	-	-	-	arch/x86/kernel/process_64.c:538
+159	adjtimex	0x9f	struct timex *txc_p	-	-	-	-	-	kernel/time.c:200
+160	setrlimit	0xa0	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1641
+161	chroot	0xa1	const char *filename	-	-	-	-	-	fs/open.c:422
+162	sync	0xa2	-	-	-	-	-	-	fs/sync.c:98
+163	acct	0xa3	const char *name	-	-	-	-	-	kernel/acct.c:255
+164	settimeofday	0xa4	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:179
+165	mount	0xa5	char *dev_name	char *dir_name	char *type	unsigned long flags	void *data	-	fs/namespace.c:2362
+166	umount2	0xa6	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+167	swapon	0xa7	const char *specialfile	int swap_flags	-	-	-	-	mm/swapfile.c:1996
+168	swapoff	0xa8	const char *specialfile	-	-	-	-	-	mm/swapfile.c:1539
+169	reboot	0xa9	int magic1	int magic2	unsigned int cmd	void *arg	-	-	kernel/sys.c:432
+170	sethostname	0xaa	char *name	int len	-	-	-	-	kernel/sys.c:1365
+171	setdomainname	0xab	char *name	int len	-	-	-	-	kernel/sys.c:1416
+172	iopl	0xac	unsigned int level	-	-	-	-	-	arch/x86/kernel/ioport.c:96
+173	ioperm	0xad	unsigned long from	unsigned long num	int turn_on	-	-	-	arch/x86/kernel/ioport.c:23
+174	create_module	-	-	-	-	-	-	-	Not implemented
+175	init_module	0xaf	void *umod	unsigned long len	const char *uargs	-	-	-	kernel/module.c:3010
+176	delete_module	0xb0	const char *name_user	unsigned int flags	-	-	-	-	kernel/module.c:768
+177	get_kernel_syms	-	-	-	-	-	-	-	Not implemented
+178	query_module	-	-	-	-	-	-	-	Not implemented
+179	quotactl	0xb3	unsigned int cmd	const char *special	qid_t id	void *addr	-	-	fs/quota/quota.c:346
+180	nfsservctl	-	-	-	-	-	-	-	Not implemented
+181	getpmsg	-	-	-	-	-	-	-	Not implemented
+182	putpmsg	-	-	-	-	-	-	-	Not implemented
+183	afs_syscall	-	-	-	-	-	-	-	Not implemented
+184	tuxcall	-	-	-	-	-	-	-	Not implemented
+185	security	-	-	-	-	-	-	-	Not implemented
+186	gettid	0xba	-	-	-	-	-	-	kernel/timer.c:1569
+187	readahead	0xbb	loff_t offset size_t count	-	-	-	-	-	mm/readahead.c:579
+188	setxattr	0xbc	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:361
+189	lsetxattr	0xbd	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:380
+190	fsetxattr	0xbe	int fd	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:399
+191	getxattr	0xbf	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:459
+192	lgetxattr	0xc0	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:473
+193	fgetxattr	0xc1	int fd	const char *name	void *value	size_t size	-	-	fs/xattr.c:487
+194	listxattr	0xc2	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:541
+195	llistxattr	0xc3	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:555
+196	flistxattr	0xc4	int fd	char *list	size_t size	-	-	-	fs/xattr.c:569
+197	removexattr	0xc5	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:602
+198	lremovexattr	0xc6	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:620
+199	fremovexattr	0xc7	int fd	const char *name	-	-	-	-	fs/xattr.c:638
+200	tkill	0xc8	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2923
+201	time	0xc9	time_t *tloc	-	-	-	-	-	kernel/time.c:62
+202	futex	0xca	u32 *uaddr	int op	u32 val	struct timespec *utime	u32 *uaddr2	u32 val3	kernel/futex.c:2680
+203	sched_setaffinity	0xcb	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4626
+204	sched_getaffinity	0xcc	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4677
+205	set_thread_area	-	-	-	-	-	-	-	Not implemented
+206	io_setup	0xce	unsigned nr_events	aio_context_t *ctxp	-	-	-	-	fs/aio.c:1298
+207	io_destroy	0xcf	aio_context_t ctx	-	-	-	-	-	fs/aio.c:1334
+208	io_getevents	0xd0	aio_context_t ctx_id	long min_nr	long nr	struct io_event *events	struct timespec *timeout	-	fs/aio.c:1844
+209	io_submit	0xd1	aio_context_t ctx_id	long nr	struct iocb * *iocbpp	-	-	-	fs/aio.c:1746
+210	io_cancel	0xd2	aio_context_t ctx_id	struct iocb *iocb	struct io_event *result	-	-	-	fs/aio.c:1781
+211	get_thread_area	-	-	-	-	-	-	-	Not implemented
+212	lookup_dcookie	0xd4	char *buf size_t len	-	-	-	-	-	fs/dcookies.c:148
+213	epoll_create	0xd5	int size	-	-	-	-	-	fs/eventpoll.c:1668
+214	epoll_ctl_old	-	-	-	-	-	-	-	Not implemented
+215	epoll_wait_old	-	-	-	-	-	-	-	Not implemented
+216	remap_file_pages	0xd8	unsigned long start	unsigned long size	unsigned long prot	unsigned long pgoff	unsigned long flags	-	mm/fremap.c:122
+217	getdents64	0xd9	unsigned int fd	struct linux_dirent64 *dirent	unsigned int count	-	-	-	fs/readdir.c:272
+218	set_tid_address	0xda	int *tidptr	-	-	-	-	-	kernel/fork.c:1109
+219	restart_syscall	0xdb	-	-	-	-	-	-	kernel/signal.c:2501
+220	semtimedop	0xdc	int semid	struct sembuf *tsops	unsigned nsops	const struct timespec *timeout	-	-	ipc/sem.c:1330
+221	fadvise64	0xdd	loff_t offset size_t len	int advice	-	-	-	-	mm/fadvise.c:148
+222	timer_create	0xde	const clockid_t which_clock	struct sigevent *timer_event_spec	timer_t *created_timer_id	-	-	-	kernel/posix-timers.c:535
+223	timer_settime	0xdf	timer_t timer_id	int flags	const struct itimerspec *new_setting	struct itimerspec *old_setting	-	-	kernel/posix-timers.c:819
+224	timer_gettime	0xe0	timer_t timer_id	struct itimerspec *setting	-	-	-	-	kernel/posix-timers.c:715
+225	timer_getoverrun	0xe1	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:751
+226	timer_delete	0xe2	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:882
+227	clock_settime	0xe3	const clockid_t which_clock	const struct timespec *tp	-	-	-	-	kernel/posix-timers.c:950
+228	clock_gettime	0xe4	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:965
+229	clock_getres	0xe5	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:1006
+230	clock_nanosleep	0xe6	const clockid_t which_clock	int flags	const struct timespec *rqtp	struct timespec *rmtp	-	-	kernel/posix-timers.c:1035
+231	exit_group	0xe7	int error_code	-	-	-	-	-	kernel/exit.c:1136
+232	epoll_wait	0xe8	int epfd	struct epoll_event *events	int maxevents	int timeout	-	-	fs/eventpoll.c:1809
+233	epoll_ctl	0xe9	int epfd	int op	int fd	struct epoll_event *event	-	-	fs/eventpoll.c:1681
+234	tgkill	0xea	pid_t tgid	pid_t pid	int sig	-	-	-	kernel/signal.c:2907
+235	utimes	0xeb	char *filename	struct timeval *utimes	-	-	-	-	fs/utimes.c:221
+236	vserver	-	-	-	-	-	-	-	Not implemented
+237	mbind	0xed	unsigned long start	unsigned long len	unsigned long mode	unsigned long *nmask	unsigned long maxnode	unsigned flags	mm/mempolicy.c:1263
+238	set_mempolicy	0xee	int mode	unsigned long *nmask	unsigned long maxnode	-	-	-	mm/mempolicy.c:1285
+239	get_mempolicy	0xef	int *policy	unsigned long *nmask	unsigned long maxnode	unsigned long addr	unsigned long flags	-	mm/mempolicy.c:1400
+240	mq_open	0xf0	const char *u_name	int oflag	umode_t mode	struct mq_attr *u_attr	-	-	ipc/mqueue.c:803
+241	mq_unlink	0xf1	const char *u_name	-	-	-	-	-	ipc/mqueue.c:876
+242	mq_timedsend	0xf2	mqd_t mqdes	const char *u_msg_ptr	size_t msg_len	unsigned int msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:971
+243	mq_timedreceive	0xf3	mqd_t mqdes	char *u_msg_ptr	size_t msg_len	unsigned int *u_msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:1092
+244	mq_notify	0xf4	mqd_t mqdes	const struct sigevent *u_notification	-	-	-	-	ipc/mqueue.c:1201
+245	mq_getsetattr	0xf5	mqd_t mqdes	const struct mq_attr *u_mqstat	struct mq_attr *u_omqstat	-	-	-	ipc/mqueue.c:1333
+246	kexec_load	0xf6	unsigned long entry	unsigned long nr_segments	struct kexec_segment *segments	unsigned long flags	-	-	kernel/kexec.c:940
+247	waitid	0xf7	int which	pid_t upid	struct siginfo *infop	int options	struct rusage *ru	-	kernel/exit.c:1763
+248	add_key	0xf8	const char *_type	const char *_description	const void *_payload	size_t plen	key_serial_t ringid	-	security/keys/keyctl.c:54
+249	request_key	0xf9	const char *_type	const char *_description	const char *_callout_info	key_serial_t destringid	-	-	security/keys/keyctl.c:147
+250	keyctl	0xfa	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	security/keys/keyctl.c:1556
+251	ioprio_set	0xfb	int which	int who	int ioprio	-	-	-	fs/ioprio.c:61
+252	ioprio_get	0xfc	int which	int who	-	-	-	-	fs/ioprio.c:176
+253	inotify_init	0xfd	-	-	-	-	-	-	fs/notify/inotify/inotify_user.c:749
+254	inotify_add_watch	0xfe	int fd	const char *pathname	u32 mask	-	-	-	fs/notify/inotify/inotify_user.c:754
+255	inotify_rm_watch	0xff	int fd	__s32 wd	-	-	-	-	fs/notify/inotify/inotify_user.c:795
+256	migrate_pages	0x100	pid_t pid	unsigned long maxnode	const unsigned long *old_nodes	const unsigned long *new_nodes	-	-	mm/mempolicy.c:1304
+257	openat	0x101	int dfd	const char *filename	int flags	umode_t mode	-	-	fs/open.c:1059
+258	mkdirat	0x102	int dfd	const char *pathname	umode_t mode	-	-	-	fs/namei.c:2723
+259	mknodat	0x103	int dfd	const char *filename	umode_t mode	unsigned dev	-	-	fs/namei.c:2646
+260	fchownat	0x104	int dfd	const char *filename	uid_t user	gid_t group	int flag	-	fs/open.c:559
+261	futimesat	0x105	int dfd	const char *filename	struct timeval *utimes	-	-	-	fs/utimes.c:193
+262	newfstatat	0x106	int dfd	const char *filename	struct stat *statbuf	int flag	-	-	fs/stat.c:269
+263	unlinkat	0x107	int dfd	const char *pathname	int flag	-	-	-	fs/namei.c:2968
+264	renameat	0x108	int olddfd	const char *oldname	int newdfd	const char *newname	-	-	fs/namei.c:3309
+265	linkat	0x109	int olddfd	const char *oldname	int newdfd	const char *newname	int flags	-	fs/namei.c:3097
+266	symlinkat	0x10a	const char *oldname	int newdfd	const char *newname	-	-	-	fs/namei.c:3004
+267	readlinkat	0x10b	int dfd	const char *pathname	char *buf	int bufsiz	-	-	fs/stat.c:293
+268	fchmodat	0x10c	int dfd	const char *filename	umode_t mode	-	-	-	fs/open.c:486
+269	faccessat	0x10d	int dfd	const char *filename	int mode	-	-	-	fs/open.c:299
+270	pselect6	0x10e	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timespec *tsp	void *sig	fs/select.c:671
+271	ppoll	0x10f	struct pollfd *ufds	unsigned int nfds	struct timespec *tsp	const sigset_t *sigmask	size_t sigsetsize	-	fs/select.c:942
+272	unshare	0x110	unsigned long unshare_flags	-	-	-	-	-	kernel/fork.c:1778
+273	set_robust_list	0x111	struct robust_list_head *head	size_t len	-	-	-	-	kernel/futex.c:2422
+274	get_robust_list	0x112	int pid	struct robust_list_head * *head_ptr	size_t *len_ptr	-	-	-	kernel/futex.c:2444
+275	splice	0x113	int fd_in	loff_t *off_in	int fd_out	loff_t *off_out	size_t len	unsigned int flags	fs/splice.c:1689
+276	tee	0x114	int fdin	int fdout	size_t len	unsigned int flags	-	-	fs/splice.c:2025
+277	sync_file_range	0x115	loff_t offset loff_t nbytes	unsigned int flags	-	-	-	-	fs/sync.c:275
+278	vmsplice	0x116	int fd	const struct iovec *iov	unsigned long nr_segs	unsigned int flags	-	-	fs/splice.c:1663
+279	move_pages	0x117	pid_t pid	unsigned long nr_pages	const void * *pages	const int *nodes	int *status	int flags	mm/migrate.c:1343
+280	utimensat	0x118	int dfd	const char *filename	struct timespec *utimes	int flags	-	-	fs/utimes.c:175
+281	epoll_pwait	0x119	int epfd	struct epoll_event *events	int maxevents	int timeout	const sigset_t *sigmask	size_t sigsetsize	fs/eventpoll.c:1860
+282	signalfd	0x11a	int ufd	sigset_t *user_mask	size_t sizemask	-	-	-	fs/signalfd.c:292
+283	timerfd_create	0x11b	int clockid	int flags	-	-	-	-	fs/timerfd.c:252
+284	eventfd	0x11c	unsigned int count	-	-	-	-	-	fs/eventfd.c:431
+285	fallocate	0x11d	int mode loff_t offset	loff_t len	-	-	-	-	fs/open.c:272
+286	timerfd_settime	0x11e	int ufd	int flags	const struct itimerspec *utmr	struct itimerspec *otmr	-	-	fs/timerfd.c:283
+287	timerfd_gettime	0x11f	int ufd	struct itimerspec *otmr	-	-	-	-	fs/timerfd.c:344
+288	accept4	0x120	int fd	struct sockaddr *upeer_sockaddr	int *upeer_addrlen	int flags	-	-	net/socket.c:1508
+289	signalfd4	0x121	int ufd	sigset_t *user_mask	size_t sizemask	int flags	-	-	fs/signalfd.c:237
+290	eventfd2	0x122	unsigned int count	int flags	-	-	-	-	fs/eventfd.c:406
+291	epoll_create1	0x123	int flags	-	-	-	-	-	fs/eventpoll.c:1625
+292	dup3	0x124	unsigned int oldfd	unsigned int newfd	int flags	-	-	-	fs/fcntl.c:53
+293	pipe2	0x125	int *fildes	int flags	-	-	-	-	fs/pipe.c:1133
+294	inotify_init1	0x126	int flags	-	-	-	-	-	fs/notify/inotify/inotify_user.c:724
+295	preadv	0x127	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:835
+296	pwritev	0x128	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:860
+297	rt_tgsigqueueinfo	0x129	pid_t tgid	pid_t pid	int sig	siginfo_t *uinfo	-	-	kernel/signal.c:2979
+298	perf_event_open	0x12a	struct perf_event_attr *attr_uptr	pid_t pid	int cpu	int group_fd	unsigned long flags	-	kernel/events/core.c:6186
+299	recvmmsg	0x12b	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	struct timespec *timeout	-	net/socket.c:2313
+300	fanotify_init	0x12c	unsigned int flags	unsigned int event_f_flags	-	-	-	-	fs/notify/fanotify/fanotify_user.c:679
+301	fanotify_mark	0x12d	unsigned int flags __u64 mask	int dfd const char *pathname	-	-	-	-	fs/notify/fanotify/fanotify_user.c:767
+302	prlimit64	0x12e	pid_t pid	unsigned int resource	const struct rlimit64 *new_rlim	struct rlimit64 *old_rlim	-	-	kernel/sys.c:1599
+303	name_to_handle_at	0x12f	int dfd	const char *name	struct file_handle *handle	int *mnt_id	int flag	-	fs/fhandle.c:92
+304	open_by_handle_at	0x130	int mountdirfd	struct file_handle *handle	int flags	-	-	-	fs/fhandle.c:257
+305	clock_adjtime	0x131	const clockid_t which_clock	struct timex *utx	-	-	-	-	kernel/posix-timers.c:983
+306	syncfs	0x132	int fd	-	-	-	-	-	fs/sync.c:134
+307	sendmmsg	0x133	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	-	-	net/socket.c:2091
+308	setns	0x134	int fd	int nstype	-	-	-	-	kernel/nsproxy.c:235
+309	getcpu	0x135	unsigned *cpup	unsigned *nodep	struct getcpu_cache *unused	-	-	-	kernel/sys.c:2179
+310	process_vm_readv	0x136	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:398
+311	process_vm_writev	0x137	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:405
+312	kcmp	0x138	pid_t pid1	pid_t pid2	int type	unsigned long idx1	unsigned long idx2	-	kernel/kcmp.c:95

--- a/addons/syscalls/tables/x86
+++ b/addons/syscalls/tables/x86
@@ -1,0 +1,347 @@
+#	Name	eax	ebx	ecx	edx	esi	edi	ebp	Definition
+0	restart_syscall	0x00	-	-	-	-	-	-	kernel/signal.c:2501
+1	exit	0x01	int error_code	-	-	-	-	-	kernel/exit.c:1095
+2	fork	0x02	-	-	-	-	-	-	arch/x86/kernel/process.c:271
+3	read	0x03	unsigned int fd	char *buf	size_t count	-	-	-	fs/read_write.c:460
+4	write	0x04	unsigned int fd	const char *buf	size_t count	-	-	-	fs/read_write.c:477
+5	open	0x05	const char *filename	int flags	umode_t mode	-	-	-	fs/open.c:1046
+6	close	0x06	unsigned int fd	-	-	-	-	-	fs/open.c:1117
+7	waitpid	0x07	pid_t pid	int *stat_addr	int options	-	-	-	kernel/exit.c:1879
+8	creat	0x08	const char *pathname	umode_t mode	-	-	-	-	fs/open.c:1079
+9	link	0x09	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3152
+10	unlink	0x0a	const char *pathname	-	-	-	-	-	fs/namei.c:2979
+11	execve	0x0b	const char *name	const char *const *argv	const char *const *envp	-	-	-	arch/x86/kernel/process.c:342
+12	chdir	0x0c	const char *filename	-	-	-	-	-	fs/open.c:375
+13	time	0x0d	time_t *tloc	-	-	-	-	-	kernel/time.c:62
+14	mknod	0x0e	const char *filename	umode_t mode	unsigned dev	-	-	-	fs/namei.c:2693
+15	chmod	0x0f	const char *filename	umode_t mode	-	-	-	-	fs/open.c:499
+16	lchown	0x10	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+17	break	-	-	-	-	-	-	-	Not implemented
+18	oldstat	0x12	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:155
+19	lseek	0x13	unsigned int fd	off_t offset	unsigned int origin	-	-	-	fs/read_write.c:230
+20	getpid	0x14	-	-	-	-	-	-	kernel/timer.c:1413
+21	mount	0x15	char *dev_name	char *dir_name	char *type	unsigned long flags	void *data	-	fs/namespace.c:2362
+22	umount	0x16	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+23	setuid	0x17	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+24	getuid	0x18	-	-	-	-	-	-	kernel/timer.c:1435
+25	stime	0x19	time_t *tptr	-	-	-	-	-	kernel/time.c:81
+26	ptrace	0x1a	long request	long pid	unsigned long addr	unsigned long data	-	-	kernel/ptrace.c:857
+27	alarm	0x1b	unsigned int seconds	-	-	-	-	-	kernel/timer.c:1390
+28	oldfstat	0x1c	unsigned int fd	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:181
+29	pause	0x1d	-	-	-	-	-	-	kernel/signal.c:3245
+30	utime	0x1e	char *filename	struct utimbuf *times	-	-	-	-	fs/utimes.c:27
+31	stty	-	-	-	-	-	-	-	Not implemented
+32	gtty	-	-	-	-	-	-	-	Not implemented
+33	access	0x21	const char *filename	int mode	-	-	-	-	fs/open.c:370
+34	nice	0x22	int increment	-	-	-	-	-	kernel/sched/core.c:4119
+35	ftime	-	-	-	-	-	-	-	Not implemented
+36	sync	0x24	-	-	-	-	-	-	fs/sync.c:98
+37	kill	0x25	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2841
+38	rename	0x26	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3403
+39	mkdir	0x27	const char *pathname	umode_t mode	-	-	-	-	fs/namei.c:2751
+40	rmdir	0x28	const char *pathname	-	-	-	-	-	fs/namei.c:2870
+41	dup	0x29	unsigned int fildes	-	-	-	-	-	fs/fcntl.c:131
+42	pipe	0x2a	int *fildes	-	-	-	-	-	fs/pipe.c:1149
+43	times	0x2b	struct tms *tbuf	-	-	-	-	-	kernel/sys.c:1058
+44	prof	-	-	-	-	-	-	-	Not implemented
+45	brk	0x2d	unsigned long brk	-	-	-	-	-	mm/mmap.c:246
+46	setgid	0x2e	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+47	getgid	0x2f	-	-	-	-	-	-	kernel/timer.c:1447
+48	signal	0x30	int sig	__sighandler_t handler	-	-	-	-	kernel/signal.c:3228
+49	geteuid	0x31	-	-	-	-	-	-	kernel/timer.c:1441
+50	getegid	0x32	-	-	-	-	-	-	kernel/timer.c:1453
+51	acct	0x33	const char *name	-	-	-	-	-	kernel/acct.c:255
+52	umount2	0x34	char *name	int flags	-	-	-	-	fs/namespace.c:1190
+53	lock	-	-	-	-	-	-	-	Not implemented
+54	ioctl	0x36	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/ioctl.c:604
+55	fcntl	0x37	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:442
+56	mpx	-	-	-	-	-	-	-	Not implemented
+57	setpgid	0x39	pid_t pid	pid_t pgid	-	-	-	-	kernel/sys.c:1083
+58	ulimit	-	-	-	-	-	-	-	Not implemented
+59	oldolduname	0x3b	struct oldold_utsname *name	-	-	-	-	-	kernel/sys.c:1330
+60	umask	0x3c	int mask	-	-	-	-	-	kernel/sys.c:1782
+61	chroot	0x3d	const char *filename	-	-	-	-	-	fs/open.c:422
+62	ustat	0x3e	unsigned dev	struct ustat *ubuf	-	-	-	-	fs/statfs.c:222
+63	dup2	0x3f	unsigned int oldfd	unsigned int newfd	-	-	-	-	fs/fcntl.c:116
+64	getppid	0x40	-	-	-	-	-	-	kernel/timer.c:1424
+65	getpgrp	0x41	-	-	-	-	-	-	kernel/sys.c:1184
+66	setsid	0x42	-	-	-	-	-	-	kernel/sys.c:1219
+67	sigaction	0x43	int sig	const struct old_sigaction *act	struct old_sigaction *oact	-	-	-	arch/x86/kernel/signal.c:487
+68	sgetmask	0x44	-	-	-	-	-	-	kernel/signal.c:3207
+69	ssetmask	0x45	int newmask	-	-	-	-	-	kernel/signal.c:3213
+70	setreuid	0x46	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+71	setregid	0x47	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+72	sigsuspend	0x48	int history0	int history1	old_sigset_t mask	-	-	-	arch/x86/kernel/signal.c:479
+73	sigpending	0x49	old_sigset_t *set	-	-	-	-	-	kernel/signal.c:3107
+74	sethostname	0x4a	char *name	int len	-	-	-	-	kernel/sys.c:1365
+75	setrlimit	0x4b	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1641
+76	getrlimit	0x4c	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+77	getrusage	0x4d	int who	struct rusage *ru	-	-	-	-	kernel/sys.c:1774
+78	gettimeofday	0x4e	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:101
+79	settimeofday	0x4f	struct timeval *tv	struct timezone *tz	-	-	-	-	kernel/time.c:179
+80	getgroups	0x50	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+81	setgroups	0x51	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+82	select	0x52	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+83	symlink	0x53	const char *oldname	const char *newname	-	-	-	-	fs/namei.c:3039
+84	oldlstat	0x54	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:168
+85	readlink	0x55	const char *path	char *buf	int bufsiz	-	-	-	fs/stat.c:321
+86	uselib	0x56	const char *library	-	-	-	-	-	fs/exec.c:116
+87	swapon	0x57	const char *specialfile	int swap_flags	-	-	-	-	mm/swapfile.c:1996
+88	reboot	0x58	int magic1	int magic2	unsigned int cmd	void *arg	-	-	kernel/sys.c:432
+89	readdir	0x59	unsigned int fd	struct old_linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:105
+90	mmap	0x5a	unsigned long addr	unsigned long len	unsigned long prot	unsigned long flags	unsigned long fd	unsigned long off	arch/x86/kernel/sys_x86_64.c:84
+91	munmap	0x5b	unsigned long addr	size_t len	-	-	-	-	mm/mmap.c:2141
+92	truncate	0x5c	const char *path	long length	-	-	-	-	fs/open.c:128
+93	ftruncate	0x5d	unsigned int fd	unsigned long length	-	-	-	-	fs/open.c:178
+94	fchmod	0x5e	unsigned int fd	umode_t mode	-	-	-	-	fs/open.c:472
+95	fchown	0x5f	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+96	getpriority	0x60	int which	int who	-	-	-	-	kernel/sys.c:241
+97	setpriority	0x61	int which	int who	int niceval	-	-	-	kernel/sys.c:172
+98	profil	-	-	-	-	-	-	-	Not implemented
+99	statfs	0x63	const char *pathname	struct statfs *buf	-	-	-	-	fs/statfs.c:166
+100	fstatfs	0x64	unsigned int fd	struct statfs *buf	-	-	-	-	fs/statfs.c:187
+101	ioperm	0x65	unsigned long from	unsigned long num	int turn_on	-	-	-	arch/x86/kernel/ioport.c:23
+102	socketcall	0x66	int call	unsigned long *args	-	-	-	-	net/socket.c:2355
+103	syslog	0x67	int type	char *buf	int len	-	-	-	kernel/printk.c:1195
+104	setitimer	0x68	int which	struct itimerval *value	struct itimerval *ovalue	-	-	-	kernel/itimer.c:278
+105	getitimer	0x69	int which	struct itimerval *value	-	-	-	-	kernel/itimer.c:103
+106	stat	0x6a	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:155
+107	lstat	0x6b	const char *filename	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:168
+108	fstat	0x6c	unsigned int fd	struct __old_kernel_stat *statbuf	-	-	-	-	fs/stat.c:181
+109	olduname	0x6d	struct oldold_utsname *name	-	-	-	-	-	kernel/sys.c:1330
+110	iopl	0x6e	unsigned int level	-	-	-	-	-	arch/x86/kernel/ioport.c:96
+111	vhangup	0x6f	-	-	-	-	-	-	fs/open.c:1156
+112	idle	-	-	-	-	-	-	-	Not implemented
+113	vm86old	0x71	struct vm86_struct *v86	-	-	-	-	-	arch/x86/kernel/vm86_32.c:203
+114	wait4	0x72	pid_t upid	int *stat_addr	int options	struct rusage *ru	-	-	kernel/exit.c:1834
+115	swapoff	0x73	const char *specialfile	-	-	-	-	-	mm/swapfile.c:1539
+116	sysinfo	0x74	struct sysinfo *info	-	-	-	-	-	kernel/timer.c:1641
+117	ipc	0x75	unsigned int call	int first	unsigned long second	unsigned long third	void *ptr	long fifth	ipc/syscall.c:16
+118	fsync	0x76	unsigned int fd	-	-	-	-	-	fs/sync.c:201
+119	sigreturn	0x77	-	-	-	-	-	-	arch/x86/kernel/signal.c:543
+120	clone	0x78	unsigned long clone_flags	unsigned long newsp	void *parent_tid	void *child_tid	-	-	arch/x86/kernel/process.c:293
+121	setdomainname	0x79	char *name	int len	-	-	-	-	kernel/sys.c:1416
+122	uname	0x7a	struct old_utsname *name	-	-	-	-	-	kernel/sys.c:1311
+123	modify_ldt	0x7b	int func	void *ptr	unsigned long bytecount	-	-	-	arch/x86/kernel/ldt.c:247
+124	adjtimex	0x7c	struct timex *txc_p	-	-	-	-	-	kernel/time.c:200
+125	mprotect	0x7d	unsigned long start	size_t len	unsigned long prot	-	-	-	mm/mprotect.c:232
+126	sigprocmask	0x7e	int how	old_sigset_t *nset	old_sigset_t *oset	-	-	-	kernel/signal.c:3125
+127	create_module	-	-	-	-	-	-	-	Not implemented
+128	init_module	0x80	void *umod	unsigned long len	const char *uargs	-	-	-	kernel/module.c:3010
+129	delete_module	0x81	const char *name_user	unsigned int flags	-	-	-	-	kernel/module.c:768
+130	get_kernel_syms	-	-	-	-	-	-	-	Not implemented
+131	quotactl	0x83	unsigned int cmd	const char *special	qid_t id	void *addr	-	-	fs/quota/quota.c:346
+132	getpgid	0x84	pid_t pid	-	-	-	-	-	kernel/sys.c:1154
+133	fchdir	0x85	unsigned int fd	-	-	-	-	-	fs/open.c:396
+134	bdflush	0x86	int func	long data	-	-	-	-	fs/buffer.c:3130
+135	sysfs	0x87	int option	unsigned long arg1	unsigned long arg2	-	-	-	fs/filesystems.c:183
+136	personality	0x88	unsigned int personality	-	-	-	-	-	kernel/exec_domain.c:182
+137	afs_syscall	-	-	-	-	-	-	-	Not implemented
+138	setfsuid	0x8a	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+139	setfsgid	0x8b	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+140	_llseek	0x8c	unsigned int fd	unsigned long offset_high	unsigned long offset_low	loff_t *result	unsigned int origin	-	fs/read_write.c:254
+141	getdents	0x8d	unsigned int fd	struct linux_dirent *dirent	unsigned int count	-	-	-	fs/readdir.c:191
+142	_newselect	0x8e	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timeval *tvp	-	fs/select.c:593
+143	flock	0x8f	unsigned int fd	unsigned int cmd	-	-	-	-	fs/locks.c:1636
+144	msync	0x90	unsigned long start	size_t len	int flags	-	-	-	mm/msync.c:31
+145	readv	0x91	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:787
+146	writev	0x92	unsigned long fd	const struct iovec *vec	unsigned long vlen	-	-	-	fs/read_write.c:808
+147	getsid	0x93	pid_t pid	-	-	-	-	-	kernel/sys.c:1191
+148	fdatasync	0x94	unsigned int fd	-	-	-	-	-	fs/sync.c:206
+149	_sysctl	0x95	struct __sysctl_args *args	-	-	-	-	-	kernel/sysctl_binary.c:1444
+150	mlock	0x96	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:482
+151	munlock	0x97	unsigned long start	size_t len	-	-	-	-	mm/mlock.c:512
+152	mlockall	0x98	int flags	-	-	-	-	-	mm/mlock.c:549
+153	munlockall	0x99	-	-	-	-	-	-	mm/mlock.c:582
+154	sched_setparam	0x9a	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4477
+155	sched_getparam	0x9b	pid_t pid	struct sched_param *param	-	-	-	-	kernel/sched/core.c:4512
+156	sched_setscheduler	0x9c	pid_t pid	int policy	struct sched_param *param	-	-	-	kernel/sched/core.c:4462
+157	sched_getscheduler	0x9d	pid_t pid	-	-	-	-	-	kernel/sched/core.c:4486
+158	sched_yield	0x9e	-	-	-	-	-	-	kernel/sched/core.c:4711
+159	sched_get_priority_max	0x9f	int policy	-	-	-	-	-	kernel/sched/core.c:4935
+160	sched_get_priority_min	0xa0	int policy	-	-	-	-	-	kernel/sched/core.c:4960
+161	sched_rr_get_interval	0xa1	pid_t pid	struct timespec *interval	-	-	-	-	kernel/sched/core.c:4985
+162	nanosleep	0xa2	struct timespec *rqtp	struct timespec *rmtp	-	-	-	-	kernel/hrtimer.c:1621
+163	mremap	0xa3	unsigned long addr	unsigned long old_len	unsigned long new_len	unsigned long flags	unsigned long new_addr	-	mm/mremap.c:431
+164	setresuid	0xa4	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+165	getresuid	0xa5	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+166	vm86	0xa6	unsigned long cmd	unsigned long arg	-	-	-	-	arch/x86/kernel/vm86_32.c:232
+167	query_module	-	-	-	-	-	-	-	Not implemented
+168	poll	0xa8	struct pollfd *ufds	unsigned int nfds	int timeout_msecs	-	-	-	fs/select.c:908
+169	nfsservctl	-	-	-	-	-	-	-	Not implemented
+170	setresgid	0xaa	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+171	getresgid	0xab	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+172	prctl	0xac	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	kernel/sys.c:1999
+173	rt_sigreturn	0xad	-	-	-	-	-	-	arch/x86/kernel/signal.c:571
+174	rt_sigaction	0xae	int sig	const struct sigaction *act	struct sigaction *oact	size_t sigsetsize	-	-	kernel/signal.c:3174
+175	rt_sigprocmask	0xaf	int how	sigset_t *nset	sigset_t *oset	size_t sigsetsize	-	-	kernel/signal.c:2591
+176	rt_sigpending	0xb0	sigset_t *set	size_t sigsetsize	-	-	-	-	kernel/signal.c:2651
+177	rt_sigtimedwait	0xb1	const sigset_t *uthese	siginfo_t *uinfo	const struct timespec *uts	size_t sigsetsize	-	-	kernel/signal.c:2805
+178	rt_sigqueueinfo	0xb2	pid_t pid	int sig	siginfo_t *uinfo	-	-	-	kernel/signal.c:2938
+179	rt_sigsuspend	0xb3	sigset_t *unewset	size_t sigsetsize	-	-	-	-	kernel/signal.c:3274
+180	pread64	0xb4	char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:495
+181	pwrite64	0xb5	const char *buf size_t count	loff_t pos	-	-	-	-	fs/read_write.c:524
+182	chown	0xb6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+183	getcwd	0xb7	char *buf	unsigned long size	-	-	-	-	fs/dcache.c:2885
+184	capget	0xb8	cap_user_header_t header	cap_user_data_t dataptr	-	-	-	-	kernel/capability.c:158
+185	capset	0xb9	cap_user_header_t header	const cap_user_data_t data	-	-	-	-	kernel/capability.c:232
+186	sigaltstack	0xba	const stack_t *uss	stack_t *uoss	-	-	-	-	arch/x86/kernel/signal.c:533
+187	sendfile	0xbb	int out_fd	int in_fd	off_t *offset	size_t count	-	-	fs/read_write.c:973
+188	getpmsg	-	-	-	-	-	-	-	Not implemented
+189	putpmsg	-	-	-	-	-	-	-	Not implemented
+190	vfork	0xbe	-	-	-	-	-	-	arch/x86/kernel/process.c:286
+191	ugetrlimit	0xbf	unsigned int resource	struct rlimit *rlim	-	-	-	-	kernel/sys.c:1440
+192	mmap2	0xc0	unsigned long addr	unsigned long len	unsigned long prot	unsigned long flags	unsigned long fd	unsigned long pgoff	mm/mmap.c:1105
+193	truncate64	0xc1	loff_t length	-	-	-	-	-	fs/open.c:188
+194	ftruncate64	0xc2	loff_t length	-	-	-	-	-	fs/open.c:200
+195	stat64	0xc3	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:372
+196	lstat64	0xc4	const char *filename	struct stat64 *statbuf	-	-	-	-	fs/stat.c:384
+197	fstat64	0xc5	unsigned long fd	struct stat64 *statbuf	-	-	-	-	fs/stat.c:396
+198	lchown32	0xc6	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:586
+199	getuid32	0xc7	-	-	-	-	-	-	kernel/timer.c:1435
+200	getgid32	0xc8	-	-	-	-	-	-	kernel/timer.c:1447
+201	geteuid32	0xc9	-	-	-	-	-	-	kernel/timer.c:1441
+202	getegid32	0xca	-	-	-	-	-	-	kernel/timer.c:1453
+203	setreuid32	0xcb	uid_t ruid	uid_t euid	-	-	-	-	kernel/sys.c:690
+204	setregid32	0xcc	gid_t rgid	gid_t egid	-	-	-	-	kernel/sys.c:557
+205	getgroups32	0xcd	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:202
+206	setgroups32	0xce	int gidsetsize	gid_t *grouplist	-	-	-	-	kernel/groups.c:231
+207	fchown32	0xcf	unsigned int fd	uid_t user	gid_t group	-	-	-	fs/open.c:605
+208	setresuid32	0xd0	uid_t ruid	uid_t euid	uid_t suid	-	-	-	kernel/sys.c:808
+209	getresuid32	0xd1	uid_t *ruidp	uid_t *euidp	uid_t *suidp	-	-	-	kernel/sys.c:873
+210	setresgid32	0xd2	gid_t rgid	gid_t egid	gid_t sgid	-	-	-	kernel/sys.c:893
+211	getresgid32	0xd3	gid_t *rgidp	gid_t *egidp	gid_t *sgidp	-	-	-	kernel/sys.c:945
+212	chown32	0xd4	const char *filename	uid_t user	gid_t group	-	-	-	fs/open.c:540
+213	setuid32	0xd5	uid_t uid	-	-	-	-	-	kernel/sys.c:761
+214	setgid32	0xd6	gid_t gid	-	-	-	-	-	kernel/sys.c:614
+215	setfsuid32	0xd7	uid_t uid	-	-	-	-	-	kernel/sys.c:969
+216	setfsgid32	0xd8	gid_t gid	-	-	-	-	-	kernel/sys.c:1008
+217	pivot_root	0xd9	const char *new_root	const char *put_old	-	-	-	-	fs/namespace.c:2453
+218	mincore	0xda	unsigned long start	size_t len	unsigned char *vec	-	-	-	mm/mincore.c:266
+219	madvise	0xdb	unsigned long start	size_t len_in	int behavior	-	-	-	mm/madvise.c:362
+220	getdents64	0xdc	unsigned int fd	struct linux_dirent64 *dirent	unsigned int count	-	-	-	fs/readdir.c:272
+221	fcntl64	0xdd	unsigned int fd	unsigned int cmd	unsigned long arg	-	-	-	fs/fcntl.c:468
+224	gettid	0xe0	-	-	-	-	-	-	kernel/timer.c:1569
+225	readahead	0xe1	loff_t offset size_t count	-	-	-	-	-	mm/readahead.c:579
+226	setxattr	0xe2	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:361
+227	lsetxattr	0xe3	const char *pathname	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:380
+228	fsetxattr	0xe4	int fd	const char *name	const void *value	size_t size	int flags	-	fs/xattr.c:399
+229	getxattr	0xe5	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:459
+230	lgetxattr	0xe6	const char *pathname	const char *name	void *value	size_t size	-	-	fs/xattr.c:473
+231	fgetxattr	0xe7	int fd	const char *name	void *value	size_t size	-	-	fs/xattr.c:487
+232	listxattr	0xe8	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:541
+233	llistxattr	0xe9	const char *pathname	char *list	size_t size	-	-	-	fs/xattr.c:555
+234	flistxattr	0xea	int fd	char *list	size_t size	-	-	-	fs/xattr.c:569
+235	removexattr	0xeb	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:602
+236	lremovexattr	0xec	const char *pathname	const char *name	-	-	-	-	fs/xattr.c:620
+237	fremovexattr	0xed	int fd	const char *name	-	-	-	-	fs/xattr.c:638
+238	tkill	0xee	pid_t pid	int sig	-	-	-	-	kernel/signal.c:2923
+239	sendfile64	0xef	int out_fd	int in_fd	loff_t *offset	size_t count	-	-	fs/read_write.c:992
+240	futex	0xf0	u32 *uaddr	int op	u32 val	struct timespec *utime	u32 *uaddr2	u32 val3	kernel/futex.c:2680
+241	sched_setaffinity	0xf1	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4626
+242	sched_getaffinity	0xf2	pid_t pid	unsigned int len	unsigned long *user_mask_ptr	-	-	-	kernel/sched/core.c:4677
+243	set_thread_area	0xf3	struct user_desc *u_info	-	-	-	-	-	arch/x86/kernel/tls.c:92
+244	get_thread_area	0xf4	struct user_desc *u_info	-	-	-	-	-	arch/x86/kernel/tls.c:142
+245	io_setup	0xf5	unsigned nr_events	aio_context_t *ctxp	-	-	-	-	fs/aio.c:1298
+246	io_destroy	0xf6	aio_context_t ctx	-	-	-	-	-	fs/aio.c:1334
+247	io_getevents	0xf7	aio_context_t ctx_id	long min_nr	long nr	struct io_event *events	struct timespec *timeout	-	fs/aio.c:1844
+248	io_submit	0xf8	aio_context_t ctx_id	long nr	struct iocb * *iocbpp	-	-	-	fs/aio.c:1746
+249	io_cancel	0xf9	aio_context_t ctx_id	struct iocb *iocb	struct io_event *result	-	-	-	fs/aio.c:1781
+250	fadvise64	0xfa	loff_t offset size_t len	int advice	-	-	-	-	mm/fadvise.c:148
+252	exit_group	0xfc	int error_code	-	-	-	-	-	kernel/exit.c:1136
+253	lookup_dcookie	0xfd	char *buf size_t len	-	-	-	-	-	fs/dcookies.c:148
+254	epoll_create	0xfe	int size	-	-	-	-	-	fs/eventpoll.c:1668
+255	epoll_ctl	0xff	int epfd	int op	int fd	struct epoll_event *event	-	-	fs/eventpoll.c:1681
+256	epoll_wait	0x100	int epfd	struct epoll_event *events	int maxevents	int timeout	-	-	fs/eventpoll.c:1809
+257	remap_file_pages	0x101	unsigned long start	unsigned long size	unsigned long prot	unsigned long pgoff	unsigned long flags	-	mm/fremap.c:122
+258	set_tid_address	0x102	int *tidptr	-	-	-	-	-	kernel/fork.c:1109
+259	timer_create	0x103	const clockid_t which_clock	struct sigevent *timer_event_spec	timer_t *created_timer_id	-	-	-	kernel/posix-timers.c:535
+260	timer_settime	0x104	timer_t timer_id	int flags	const struct itimerspec *new_setting	struct itimerspec *old_setting	-	-	kernel/posix-timers.c:819
+261	timer_gettime	0x105	timer_t timer_id	struct itimerspec *setting	-	-	-	-	kernel/posix-timers.c:715
+262	timer_getoverrun	0x106	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:751
+263	timer_delete	0x107	timer_t timer_id	-	-	-	-	-	kernel/posix-timers.c:882
+264	clock_settime	0x108	const clockid_t which_clock	const struct timespec *tp	-	-	-	-	kernel/posix-timers.c:950
+265	clock_gettime	0x109	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:965
+266	clock_getres	0x10a	const clockid_t which_clock	struct timespec *tp	-	-	-	-	kernel/posix-timers.c:1006
+267	clock_nanosleep	0x10b	const clockid_t which_clock	int flags	const struct timespec *rqtp	struct timespec *rmtp	-	-	kernel/posix-timers.c:1035
+268	statfs64	0x10c	const char *pathname	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:175
+269	fstatfs64	0x10d	unsigned int fd	size_t sz	struct statfs64 *buf	-	-	-	fs/statfs.c:196
+270	tgkill	0x10e	pid_t tgid	pid_t pid	int sig	-	-	-	kernel/signal.c:2907
+271	utimes	0x10f	char *filename	struct timeval *utimes	-	-	-	-	fs/utimes.c:221
+272	fadvise64_64	0x110	loff_t offset loff_t len	int advice	-	-	-	-	mm/fadvise.c:27
+273	vserver	-	-	-	-	-	-	-	Not implemented
+274	mbind	0x112	unsigned long start	unsigned long len	unsigned long mode	unsigned long *nmask	unsigned long maxnode	unsigned flags	mm/mempolicy.c:1263
+275	get_mempolicy	0x113	int *policy	unsigned long *nmask	unsigned long maxnode	unsigned long addr	unsigned long flags	-	mm/mempolicy.c:1400
+276	set_mempolicy	0x114	int mode	unsigned long *nmask	unsigned long maxnode	-	-	-	mm/mempolicy.c:1285
+277	mq_open	0x115	const char *u_name	int oflag	umode_t mode	struct mq_attr *u_attr	-	-	ipc/mqueue.c:803
+278	mq_unlink	0x116	const char *u_name	-	-	-	-	-	ipc/mqueue.c:876
+279	mq_timedsend	0x117	mqd_t mqdes	const char *u_msg_ptr	size_t msg_len	unsigned int msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:971
+280	mq_timedreceive	0x118	mqd_t mqdes	char *u_msg_ptr	size_t msg_len	unsigned int *u_msg_prio	const struct timespec *u_abs_timeout	-	ipc/mqueue.c:1092
+281	mq_notify	0x119	mqd_t mqdes	const struct sigevent *u_notification	-	-	-	-	ipc/mqueue.c:1201
+282	mq_getsetattr	0x11a	mqd_t mqdes	const struct mq_attr *u_mqstat	struct mq_attr *u_omqstat	-	-	-	ipc/mqueue.c:1333
+283	kexec_load	0x11b	unsigned long entry	unsigned long nr_segments	struct kexec_segment *segments	unsigned long flags	-	-	kernel/kexec.c:940
+284	waitid	0x11c	int which	pid_t upid	struct siginfo *infop	int options	struct rusage *ru	-	kernel/exit.c:1763
+286	add_key	0x11e	const char *_type	const char *_description	const void *_payload	size_t plen	key_serial_t ringid	-	security/keys/keyctl.c:54
+287	request_key	0x11f	const char *_type	const char *_description	const char *_callout_info	key_serial_t destringid	-	-	security/keys/keyctl.c:147
+288	keyctl	0x120	int option	unsigned long arg2	unsigned long arg3	unsigned long arg4	unsigned long arg5	-	security/keys/keyctl.c:1556
+289	ioprio_set	0x121	int which	int who	int ioprio	-	-	-	fs/ioprio.c:61
+290	ioprio_get	0x122	int which	int who	-	-	-	-	fs/ioprio.c:176
+291	inotify_init	0x123	-	-	-	-	-	-	fs/notify/inotify/inotify_user.c:749
+292	inotify_add_watch	0x124	int fd	const char *pathname	u32 mask	-	-	-	fs/notify/inotify/inotify_user.c:754
+293	inotify_rm_watch	0x125	int fd	__s32 wd	-	-	-	-	fs/notify/inotify/inotify_user.c:795
+294	migrate_pages	0x126	pid_t pid	unsigned long maxnode	const unsigned long *old_nodes	const unsigned long *new_nodes	-	-	mm/mempolicy.c:1304
+295	openat	0x127	int dfd	const char *filename	int flags	umode_t mode	-	-	fs/open.c:1059
+296	mkdirat	0x128	int dfd	const char *pathname	umode_t mode	-	-	-	fs/namei.c:2723
+297	mknodat	0x129	int dfd	const char *filename	umode_t mode	unsigned dev	-	-	fs/namei.c:2646
+298	fchownat	0x12a	int dfd	const char *filename	uid_t user	gid_t group	int flag	-	fs/open.c:559
+299	futimesat	0x12b	int dfd	const char *filename	struct timeval *utimes	-	-	-	fs/utimes.c:193
+300	fstatat64	0x12c	int dfd	const char *filename	struct stat64 *statbuf	int flag	-	-	fs/stat.c:407
+301	unlinkat	0x12d	int dfd	const char *pathname	int flag	-	-	-	fs/namei.c:2968
+302	renameat	0x12e	int olddfd	const char *oldname	int newdfd	const char *newname	-	-	fs/namei.c:3309
+303	linkat	0x12f	int olddfd	const char *oldname	int newdfd	const char *newname	int flags	-	fs/namei.c:3097
+304	symlinkat	0x130	const char *oldname	int newdfd	const char *newname	-	-	-	fs/namei.c:3004
+305	readlinkat	0x131	int dfd	const char *pathname	char *buf	int bufsiz	-	-	fs/stat.c:293
+306	fchmodat	0x132	int dfd	const char *filename	umode_t mode	-	-	-	fs/open.c:486
+307	faccessat	0x133	int dfd	const char *filename	int mode	-	-	-	fs/open.c:299
+308	pselect6	0x134	int n	fd_set *inp	fd_set *outp	fd_set *exp	struct timespec *tsp	void *sig	fs/select.c:671
+309	ppoll	0x135	struct pollfd *ufds	unsigned int nfds	struct timespec *tsp	const sigset_t *sigmask	size_t sigsetsize	-	fs/select.c:942
+310	unshare	0x136	unsigned long unshare_flags	-	-	-	-	-	kernel/fork.c:1778
+311	set_robust_list	0x137	struct robust_list_head *head	size_t len	-	-	-	-	kernel/futex.c:2422
+312	get_robust_list	0x138	int pid	struct robust_list_head * *head_ptr	size_t *len_ptr	-	-	-	kernel/futex.c:2444
+313	splice	0x139	int fd_in	loff_t *off_in	int fd_out	loff_t *off_out	size_t len	unsigned int flags	fs/splice.c:1689
+314	sync_file_range	0x13a	loff_t offset loff_t nbytes	unsigned int flags	-	-	-	-	fs/sync.c:275
+315	tee	0x13b	int fdin	int fdout	size_t len	unsigned int flags	-	-	fs/splice.c:2025
+316	vmsplice	0x13c	int fd	const struct iovec *iov	unsigned long nr_segs	unsigned int flags	-	-	fs/splice.c:1663
+317	move_pages	0x13d	pid_t pid	unsigned long nr_pages	const void * *pages	const int *nodes	int *status	int flags	mm/migrate.c:1343
+318	getcpu	0x13e	unsigned *cpup	unsigned *nodep	struct getcpu_cache *unused	-	-	-	kernel/sys.c:2179
+319	epoll_pwait	0x13f	int epfd	struct epoll_event *events	int maxevents	int timeout	const sigset_t *sigmask	size_t sigsetsize	fs/eventpoll.c:1860
+320	utimensat	0x140	int dfd	const char *filename	struct timespec *utimes	int flags	-	-	fs/utimes.c:175
+321	signalfd	0x141	int ufd	sigset_t *user_mask	size_t sizemask	-	-	-	fs/signalfd.c:292
+322	timerfd_create	0x142	int clockid	int flags	-	-	-	-	fs/timerfd.c:252
+323	eventfd	0x143	unsigned int count	-	-	-	-	-	fs/eventfd.c:431
+324	fallocate	0x144	int mode loff_t offset	loff_t len	-	-	-	-	fs/open.c:272
+325	timerfd_settime	0x145	int ufd	int flags	const struct itimerspec *utmr	struct itimerspec *otmr	-	-	fs/timerfd.c:283
+326	timerfd_gettime	0x146	int ufd	struct itimerspec *otmr	-	-	-	-	fs/timerfd.c:344
+327	signalfd4	0x147	int ufd	sigset_t *user_mask	size_t sizemask	int flags	-	-	fs/signalfd.c:237
+328	eventfd2	0x148	unsigned int count	int flags	-	-	-	-	fs/eventfd.c:406
+329	epoll_create1	0x149	int flags	-	-	-	-	-	fs/eventpoll.c:1625
+330	dup3	0x14a	unsigned int oldfd	unsigned int newfd	int flags	-	-	-	fs/fcntl.c:53
+331	pipe2	0x14b	int *fildes	int flags	-	-	-	-	fs/pipe.c:1133
+332	inotify_init1	0x14c	int flags	-	-	-	-	-	fs/notify/inotify/inotify_user.c:724
+333	preadv	0x14d	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:835
+334	pwritev	0x14e	unsigned long fd	const struct iovec *vec	unsigned long vlen	unsigned long pos_l	unsigned long pos_h	-	fs/read_write.c:860
+335	rt_tgsigqueueinfo	0x14f	pid_t tgid	pid_t pid	int sig	siginfo_t *uinfo	-	-	kernel/signal.c:2979
+336	perf_event_open	0x150	struct perf_event_attr *attr_uptr	pid_t pid	int cpu	int group_fd	unsigned long flags	-	kernel/events/core.c:6186
+337	recvmmsg	0x151	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	struct timespec *timeout	-	net/socket.c:2313
+338	fanotify_init	0x152	unsigned int flags	unsigned int event_f_flags	-	-	-	-	fs/notify/fanotify/fanotify_user.c:679
+339	fanotify_mark	0x153	unsigned int flags __u64 mask	int dfd const char *pathname	-	-	-	-	fs/notify/fanotify/fanotify_user.c:767
+340	prlimit64	0x154	pid_t pid	unsigned int resource	const struct rlimit64 *new_rlim	struct rlimit64 *old_rlim	-	-	kernel/sys.c:1599
+341	name_to_handle_at	0x155	int dfd	const char *name	struct file_handle *handle	int *mnt_id	int flag	-	fs/fhandle.c:92
+342	open_by_handle_at	0x156	int mountdirfd	struct file_handle *handle	int flags	-	-	-	fs/fhandle.c:257
+343	clock_adjtime	0x157	const clockid_t which_clock	struct timex *utx	-	-	-	-	kernel/posix-timers.c:983
+344	syncfs	0x158	int fd	-	-	-	-	-	fs/sync.c:134
+345	sendmmsg	0x159	int fd	struct mmsghdr *mmsg	unsigned int vlen	unsigned int flags	-	-	net/socket.c:2091
+346	setns	0x15a	int fd	int nstype	-	-	-	-	kernel/nsproxy.c:235
+347	process_vm_readv	0x15b	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:398
+348	process_vm_writev	0x15c	pid_t pid	const struct iovec *lvec	unsigned long liovcnt	const struct iovec *rvec	unsigned long riovcnt	unsigned long flags	mm/process_vm_access.c:405
+349	kcmp	0x15d	pid_t pid1	pid_t pid2	int type	unsigned long idx1	unsigned long idx2	-	kernel/kcmp.c:95

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
   "challenge_handler",
-  "ping_handler"
+  "ping_handler",
+  "syscalls_handler"
 ]
 

--- a/handlers/syscalls_handler.py
+++ b/handlers/syscalls_handler.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+import shlex
+import re
+import json
+import time
+from helpers.command import *
+from helpers.invalid_command import *
+from unidecode import unidecode
+from addons.syscalls.syscallinfo import *
+
+def parseSyscallInfo(syscallEntry):  
+  msg = "```"
+
+  for entry in syscallEntry:
+    msg += "{0:15} : {1}\n".format(entry, syscallEntry[entry])
+  
+  return msg.strip() + "```"  
+
+class ShowAvailableArchCommand(Command):
+  """
+    Shows the available architecture tables for syscalls
+  """
+
+  def __init__(self, channel, user, syscallInfo):
+    self.user = user
+    self.syscallInfo = syscallInfo
+    self.channel = channel
+
+  def showUsage(self):
+    msg  
+
+  def execute(self, slack_client):    
+    archList = self.syscallInfo.getAvailableArchitectures()
+
+    msg = "\n"
+    msg += "Available architectures:\n"
+    msg += "```"
+
+    for arch in archList:
+      msg += "%s\t" % arch
+
+    msg += "```\n"
+
+    slack_client.api_call("chat.postMessage",
+        channel=self.channel, text=msg.strip(), as_user=True)
+  
+class ShowSyscallCommand(Command):
+  """
+    Shows information about the requested syscall
+  """
+
+  def __init__(self, args, channel, user, syscallInfo):
+    if len(args) < 2:
+      raise InvalidCommand("Usage : ```@ota_bot syscalls show <arch> <syscall name / syscall id>```")
+
+    self.user = user
+    self.syscallInfo = syscallInfo
+    self.channel = channel
+    self.args = args
+
+  def sendMessage(self, slack_client, msg):
+    destChannel = self.channel if (SyscallsHandler.MSGMODE == 0) else self.user
+
+    slack_client.api_call("chat.postMessage", 
+      channel=destChannel, text=msg.strip(), as_user=True)    
+
+  def execute(self, slack_client):
+    
+    archObj = self.syscallInfo.getArch(self.args[0])
+
+    if archObj:
+      entry = None
+
+      # convenience : Try to search syscall by id or by name, depending on what
+      # the user has specified
+      try:
+        syscallID = int(self.args[1])
+        entry = archObj.getEntryByID(syscallID)
+      except:
+        entry = archObj.getEntryByName(self.args[1])
+
+      if entry:
+        msg = parseSyscallInfo(entry)
+        
+        self.sendMessage(slack_client, msg)
+      else:
+        msg = "Specified syscall not found: `%s (Arch: %s)`" % (self.args[1], self.args[0])
+
+        self.sendMessage(slack_client, msg)
+    else:
+      msg = "Specified architecture not available: `%s`" % self.args[0]
+
+      self.sendMessage(slack_client, msg)
+
+class SyscallHelpCommand(Command):
+    """
+      Displays a help menu
+    """
+
+    def execute(self, slack_client):
+      message = "```"
+      message += "@ota_bot syscalls available\n"
+      message += "@ota_bot syscalls show <arch> <syscall name/syscall id>\n"
+      message += "```"
+
+      raise InvalidCommand(message)
+
+
+class SyscallsHandler:
+  """
+    Shows information about syscalls for different architectures.
+
+    Commands :
+    # Show available architectures
+    @ota_bot syscalls available
+
+    # Show syscall information 
+    @ota_bot syscalls show x86 execve
+    @ota_bot syscalls show x86 11    
+  """
+
+  # Specify the base directory, where the syscall tables are located
+  BASEDIR = "addons/syscalls/tables"
+  
+  # Specify if messages from syscall handler should be posted to channel (0) or per dm (1)
+  MSGMODE = 0
+
+  def __init__(self, slack_client):
+    self.syscallInfo = SyscallInfo(SyscallsHandler.BASEDIR)
+
+    self.slack_client = slack_client    
+
+  def process(self, command, channel, user):
+    try:
+      command_line = unidecode(command.lower())
+      args = shlex.split(command_line)
+      command = None
+    except:
+      message = "Command failed : Malformed input."
+      self.slack_client.api_call("chat.postMessage",
+        channel=channel, text=message, as_user=True)
+      return
+
+    try:
+      # Show available architectures
+      if args[:2] == ["syscalls", "available"]:
+        command = ShowAvailableArchCommand(channel, user, self.syscallInfo)
+
+      # Show specific syscall
+      elif args[:2] == ["syscalls", "show"]:
+        command = ShowSyscallCommand(args[2:], channel, user, self.syscallInfo)
+
+      elif args[:1] == ["help"]:
+        command = SyscallHelpCommand()
+
+      if command:
+        command.execute(self.slack_client)
+
+    except InvalidCommand as e:
+      self.slack_client.api_call("chat.postMessage",
+        channel=channel, text=e.message, as_user=True)
+

--- a/run.py
+++ b/run.py
@@ -56,7 +56,8 @@ if __name__ == "__main__":
   # Connect to Slack's real-time messaging API
   handlers = [
     ping_handler.PingHandler(slack_client),
-    challenge_handler.ChallengeHandler(slack_client, BOT_ID)
+    challenge_handler.ChallengeHandler(slack_client, BOT_ID),
+    syscalls_handler.SyscallsHandler(slack_client)
   ]
 
   if slack_client.rtm_connect():


### PR DESCRIPTION
Let OTABot do more than just managing channels ;)

- Parses syscall tables
- Show information for specified syscalls
- with MSGMODE in SyscallsHandler it can be specified for now, if the syscall info will be posted to chat or direct message (maybe add some configuration system for "addons" later on)

Well, it might be arguable, if this is i a worthy addition, but at least, I don't have to lookup syscalls anymore, scrolling up and down to see, which registers match :P

```
@ota_bot syscalls available
@ota_bot syscalls show <arch> <syscall name/syscall id>
```

```
@ota_bot syscalls show x64 read

#               : 0
Name            : read
rax             : 0x00
rdi             : unsigned int fd
rsi             : char *buf
rdx             : size_t count
rcx             : -
r8              : -
r9              : -
Definition      : fs/read_write.c:460

@ota_bot syscalls show x86 execve

#               : 11
Name            : execve
eax             : 0x0b
ebx             : const char *name
ecx             : const char *const *argv
edx             : const char *const *envp
esi             : -
edi             : -
ebp             : -
Definition      : arch/x86/kernel/process.c:342

@ota_bot syscalls show armthumb 11

#               : 11
Name            : execve
r7              : 0x0b
r0              : const char *filenamei
r1              : const char *const *argv
r2              : const char *const *envp
r3              : -
r4              : -
r5              : -
Definition      : arch/arm/kernel/sys_arm.c:65```