### PR TITLE
Log the backtrace

### DIFF
--- a/handlers/handler_factory.py
+++ b/handlers/handler_factory.py
@@ -90,4 +90,4 @@ class HandlerFactory():
         except InvalidCommand as e:
             slack_client.api_call("chat.postMessage", channel=channel, text=e.message, as_user=True)
         except Exception as ex:
-            log.error("An error has occured while processing a command: %s" % ex)
+            log.exception("An error has occured while processing a command")


### PR DESCRIPTION
Eg `!status` was blowing up for me without saying why:
Before:
```
2017-08-27 22:34:14,887 - handler_factory      - An error has occured while processing a command: presence
```
After:
```
2017-08-27 22:34:14,887 - handler_factory      - An error has occured while processing a command
Traceback (most recent call last):
  File "/src/handlers/handler_factory.py", line 80, in process
    handler.process(slack_client, command, args[1:], channel, user)
  File "/src/handlers/base_handler.py", line 66, in process
    cmdDescriptor.command().execute(slack_client, args, channel, user)
  File "/src/handlers/challenge_handler.py", line 105, in execute
    members = {m["id"]: m["name"] for m in get_members(slack_client)['members'] if m["presence"] == "active"}
  File "/src/handlers/challenge_handler.py", line 105, in <dictcomp>
    members = {m["id"]: m["name"] for m in get_members(slack_client)['members'] if m["presence"] == "active"}
KeyError: 'presence'
```