### PR TITLE
Send help through DM / Added console configuration

### DIFF
--- a/bottypes/invalid_console_command.py
+++ b/bottypes/invalid_console_command.py
@@ -1,0 +1,8 @@
+class InvalidConsoleCommand(Exception):
+    """
+    Exception for invalid console commands.
+    The message should be the usage for that command.
+    """
+
+    def __init__(self, message):
+        self.message = message

--- a/config.json.template
+++ b/config.json.template
@@ -1,4 +1,5 @@
 {
   "api_key" : "",
-  "bot_name" : ""
+  "bot_name" : "",
+  "send_help_as_dm" : "1"
 }

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -100,6 +100,7 @@ class AddChallengeCommand(Command):
         slack_client.api_call("chat.postMessage",
                               channel=channel_id, text="New challenge {} created in channel #{}".format(name, channel_name), as_user=True)
 
+
 class StatusCommand(Command):
     """
     Get a status of the currently running CTFs.
@@ -107,13 +108,15 @@ class StatusCommand(Command):
 
     def execute(self, slack_client, args, channel_id, user_id):
         ctfs = pickle.load(open(ChallengeHandler.DB, "rb"))
-        members = {m["id"]: m["name"] for m in get_members(slack_client) if m.get("presence") == "active"}
+        members = {m["id"]: m["name"] for m in get_members(
+            slack_client) if m.get("presence") == "active"}
         response = ""
         for ctf in ctfs:
             response += "*============= %s =============*\n" % ctf.name
             for challenge in ctf.challenges:
                 channel_name = "%s-%s" % (ctf.name, challenge.name)
-                response += "*%s* #%s (Total : %d) " % (challenge.name, channel_name, len(challenge.players))
+                response += "*%s* #%s (Total : %d) " % (challenge.name,
+                                                        channel_name, len(challenge.players))
                 players = []
                 if challenge.is_solved:
                     response += "Solved by : %s :tada:\n" % ", ".join(

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ from server.botserver import *
 from server.consolethread import *
 
 
-if __name__  == "__main__":
+if __name__ == "__main__":
     log.info("Initializing threads...")
 
     server = BotServer()

--- a/util/config.py
+++ b/util/config.py
@@ -1,1 +1,0 @@
-SEND_HELP_AS_DM = True


### PR DESCRIPTION
- Reimplemented "Send help through DM"

If the configuration "send_help_as_dm" is set to "1" the usage messages will be sent to the user via direct message. You'll need to update the config.json file and add that option from the template.

- Added console configuration command "set"

`set` will show the usage and available options. Only options already existing in the config.json can be set, to avoid littering the config file.

`set <option> <value>` will set the option and saves the updated json file.

```
set

Usage: set <option> <value>

Available options:
bot_name             = kbot
api_key              = XXXX
send_help_as_dm      = 0

set send_help_as_dm 1

set test abc
2017-08-28 11:40:15,945 - consolethread        - The specified configuration option doesn't exist: test
```

Fixes #1 
