### PR TITLE
Add "as" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Secondary features :
 !admin show_admins    (Show a list of current admin users)
 !admin add_admin <user_id>    (Add an user to the admin user group)
 !admin remove_admin <user_id>    (Remove an user from the admin user group)
+!admin as <@user> <command>    (Execute a command as another user)
 ```
 
 ## Installation

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -114,13 +114,9 @@ class AsCommand(Command):
 
         if user_obj['ok']:
             dest_user_id = user_obj['user']['id']
-
-            dest_args = [ dest_command ]
-            for arg in dest_arguments:
-                dest_args.append(arg)
-
+            
             # Redirecting command execution to handler factory
-            HandlerFactory.process_command(slack_wrapper, dest_command, dest_args, channel_id, dest_user_id)
+            HandlerFactory.process_command(slack_wrapper, dest_command, [dest_command] + dest_arguments, channel_id, dest_user_id)
         else:
             raise InvalidCommand("You have to specify a valid user (use @-notation).")
 

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -100,6 +100,31 @@ class RemoveAdminCommand(Command):
                 slack_wrapper, channel_id, user_id, response)
 
 
+class AsCommand(Command):
+    """Execute a command as another user."""
+
+    def execute(self, slack_wrapper, args, channel_id, user_id):
+        """Execute the As command."""
+        dest_user = args[0].lower()
+        dest_command = args[1].lower()
+
+        dest_arguments = args[2:]
+
+        user_obj = resolve_user_by_user_id(slack_wrapper, dest_user)
+
+        if user_obj['ok']:
+            dest_user_id = user_obj['user']['id']
+
+            dest_args = [ dest_command ]
+            for arg in dest_arguments:
+                dest_args.append(arg)
+
+            # Redirecting command execution to handler factory
+            HandlerFactory.process_command(slack_wrapper, dest_command, dest_args, channel_id, dest_user_id)
+        else:
+            raise InvalidCommand("You have to specify a valid user (use @-notation).")
+
+
 class AdminHandler(BaseHandler):
     """
     Handles configuration options for administrators.
@@ -129,7 +154,8 @@ class AdminHandler(BaseHandler):
         self.commands = {
             "show_admins": CommandDesc(ShowAdminsCommand, "Show a list of current admin users", None, None, True),
             "add_admin": CommandDesc(AddAdminCommand, "Add a user to the admin user group", ["user_id"], None, True),
-            "remove_admin": CommandDesc(RemoveAdminCommand, "Remove a user from the admin user group", ["user_id"], None, True)
+            "remove_admin": CommandDesc(RemoveAdminCommand, "Remove a user from the admin user group", ["user_id"], None, True),
+            "as" : CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True)
         }
 
 

--- a/handlers/handler_factory.py
+++ b/handlers/handler_factory.py
@@ -33,18 +33,18 @@ class HandlerFactory():
     def process(slack_wrapper, botserver, message, channel_id, user_id):
         log.debug("Processing message: {} from {} ({})".format(message, channel_id, user_id))
 
-        try: # Parse command and check for malformed input
+        try:  # Parse command and check for malformed input
             command_line = unidecode(message.lower())
             args = shlex.split(command_line)
         except:
             message = "Command failed : Malformed input."
             slack_wrapper.post_message(channel_id, message)
             return
-            
+
         HandlerFactory.process_command(slack_wrapper, message, args, channel_id, user_id)
 
     def process_command(slack_wrapper, message, args, channel_id, user_id):
-        
+
         try:
             handler_name = args[0]
             processed = False
@@ -52,7 +52,7 @@ class HandlerFactory():
 
             admin_users = HandlerFactory.botserver.get_config_option("admin_users")
             user_is_admin = admin_users and user_id in admin_users
-    
+
             # Call a specific handler with this command
             handler = HandlerFactory.handlers.get(handler_name)
 
@@ -62,31 +62,31 @@ class HandlerFactory():
                     usage_msg += handler.get_usage(user_is_admin)
                     processed = True
 
-                else: # Send command to specified handler
+                else:  # Send command to specified handler
                     command = args[1]
                     if handler.can_handle(command, user_is_admin):
                         handler.process(slack_wrapper, command, args[2:], channel_id, user_id, user_is_admin)
                         processed = True
 
-            else: # Pass the command to every available handler
+            else:  # Pass the command to every available handler
                 command = args[0]
 
                 for handler_name, handler in HandlerFactory.handlers.items():
-                    if command == "help": # Setup usage message
+                    if command == "help":  # Setup usage message
                         usage_msg += "{}\n".format(handler.get_usage(user_is_admin))
                         processed = True
 
-                    elif handler.can_handle(command, user_is_admin): # Send command to handler
+                    elif handler.can_handle(command, user_is_admin):  # Send command to handler
                         handler.process(slack_wrapper, command,
                                         args[1:], channel_id, user_id, user_is_admin)
                         processed = True
 
-            if not processed: # Send error message
+            if not processed:  # Send error message
                 message = "Unknown handler or command : `{}`".format(message)
                 slack_wrapper.post_message(channel_id, message)
 
-            if usage_msg: # Send usage message 
-                send_help_as_dm = HandlerFactory.botserver.get_config_option("send_help_as_dm") == "1"               
+            if usage_msg:  # Send usage message
+                send_help_as_dm = HandlerFactory.botserver.get_config_option("send_help_as_dm") == "1"
                 target_id = user_id if send_help_as_dm else channel_id
                 slack_wrapper.post_message(target_id, usage_msg)
 

--- a/handlers/handler_factory.py
+++ b/handlers/handler_factory.py
@@ -40,15 +40,19 @@ class HandlerFactory():
             message = "Command failed : Malformed input."
             slack_wrapper.post_message(channel_id, message)
             return
+            
+        HandlerFactory.process_command(slack_wrapper, message, args, channel_id, user_id)
 
+    def process_command(slack_wrapper, message, args, channel_id, user_id):
+        
         try:
             handler_name = args[0]
             processed = False
             usage_msg = ""
 
-            admin_users = botserver.get_config_option("admin_users")
+            admin_users = HandlerFactory.botserver.get_config_option("admin_users")
             user_is_admin = admin_users and user_id in admin_users
-
+    
             # Call a specific handler with this command
             handler = HandlerFactory.handlers.get(handler_name)
 
@@ -81,8 +85,8 @@ class HandlerFactory():
                 message = "Unknown handler or command : `{}`".format(message)
                 slack_wrapper.post_message(channel_id, message)
 
-            if usage_msg: # Send usage message
-                send_help_as_dm = botserver.get_config_option("send_help_as_dm") == "1"
+            if usage_msg: # Send usage message 
+                send_help_as_dm = HandlerFactory.botserver.get_config_option("send_help_as_dm") == "1"               
                 target_id = user_id if send_help_as_dm else channel_id
                 slack_wrapper.post_message(target_id, usage_msg)
 


### PR DESCRIPTION
Added an admin command "as" (as proposed by @Grazfather), which can be used to execute arbitrary commands as another user.

You'll have to use @-notation for this.

Example:

`!as @user solve challenge supporter`

will result in executing

`!solve challenge supporter` 

as the specified user.

With this, the issue "Solve as" should be covered as any other situation, where we might to execute a command as a specific user, without having to reimplement the command handlers multiple times.

Fixes #59 