### PR TITLE
Add version command for bothandler to show git information

### DIFF
--- a/handlers/bot_handler.py
+++ b/handlers/bot_handler.py
@@ -9,6 +9,7 @@ from bottypes.command import *
 from bottypes.command_descriptor import *
 from handlers.handler_factory import *
 from handlers.base_handler import *
+from util.githandler import GitHandler
 
 
 class PingCommand(Command):
@@ -17,6 +18,7 @@ class PingCommand(Command):
     def execute(self, slack_wrapper, args, channel_id, user_id):
         """Announce the bot's presence in the channel."""
         slack_wrapper.post_message(channel_id, "Pong!")
+
 
 class IntroCommand(Command):
     """Show an introduction message for new members."""
@@ -34,13 +36,29 @@ class IntroCommand(Command):
             slack_wrapper.post_message(channel_id, message)
 
 
+class VersionCommand(Command):
+    """Show git information about the current running version of the bot."""
+
+    def execute(self, slack_wrapper, args, channel_id, user_id):
+        """Execute the Version command."""
+        try:
+            message = GitHandler(".").get_version()
+
+            slack_wrapper.post_message(channel_id, message)
+        except:
+            log.exception("BotHandler::VersionCommand")
+            raise InvalidCommand("Sorry, couldn't retrieve the git information for the bot...")
+
+
 class BotHandler(BaseHandler):
     """Handler for generic bot commands."""
 
     def __init__(self):
         self.commands = {
             "ping": CommandDesc(PingCommand, "Ping the bot", None, None),
-            "intro": CommandDesc(IntroCommand, "Show an introduction message for new members", None, None)
+            "intro": CommandDesc(IntroCommand, "Show an introduction message for new members", None, None),
+            "version": CommandDesc(VersionCommand, "Show git information about the running version of the bot", None, None)
         }
+
 
 HandlerFactory.register("bot", BotHandler())


### PR DESCRIPTION
`!version`

shows the current branch / current commit + commit message

bot [12:54 PM]
I'm running commit `60c6da161980e95229e9c6fdd3269fcdf0ca53ff` of branch `gitversion`

```
Merge pull request #108 from OpenToAllCTF/gitrefactor

Refactor GitHandler / Solvetracker
```

Fixes #97 