### PR TITLE
Add mandatory long name for ctf and merged post solves and archivectf

### DIFF
--- a/bottypes/ctf.py
+++ b/bottypes/ctf.py
@@ -1,6 +1,6 @@
 class CTF:
 
-    def __init__(self, channel_id, name):
+    def __init__(self, channel_id, name, long_name):
         """
         An object representation of an ongoing CTF.
         channel_id : The slack id for the associated channel
@@ -13,6 +13,7 @@ class CTF:
         self.cred_user = ""
         self.cred_pw = ""
         self.cred_url = ""
+        self.long_name = long_name
 
     def add_challenge(self, challenge):
         """


### PR DESCRIPTION
- CTF's now have a "long name" as mandatory argument (for uploading it to git)
- Archiving a ctf while having git support active will automatically upload the solve post
- Archiving a ctf will fail if solves couldn't be uploaded successfully

Fixes #112