### PR TITLE
Add 'auto_invite' option of users to invite to ctf chans

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -3,5 +3,6 @@
   "bot_name" : "",
   "send_help_as_dm" : "1",
   "admin_users" : [],
+  "auto_invite" : [],
   "wolfram_app_id" : ""
 }


### PR DESCRIPTION
If there's an auto_invite list in the config, whenever a channel for a challenge or a ctf is created, invite everyone in that list.

This is so that bots (mostly) can be added to channels automatically.