### PR TITLE
Support reloading CTF data from private CTF channels

### DIFF
--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -644,10 +644,11 @@ class ChallengeHandler(BaseHandler):
         Reload the ctf and challenge information from slack.
         """
         database = {}
-        response = slack_wrapper.get_public_channels()
+        privchans = slack_wrapper.get_private_channels()["groups"]
+        pubchans = slack_wrapper.get_public_channels()["channels"]
 
         # Find active CTF channels
-        for channel in response['channels']:
+        for channel in [*privchans, *pubchans]:
             purpose = load_json(channel['purpose']['value'])
 
             if not channel['is_archived'] and purpose and "ota_bot" in purpose and purpose["type"] == "CTF":


### PR DESCRIPTION
This way we can turn the main channel private but still have the bot restore the list.

Note that this still leaks all info of the existing ctfs and their challenges with `!solve`