### PR TITLE
Save useful links shared in slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ Example:
 1. Setup a github repo with jekyll and staticman (e.g. https://github.com/ujjwal96/links).
 2. Copy `config_savelink.json.template` to `config_savelink.json`.
 3. Configure the git repo and branch to be used.
+4. Add the decrypted staticman-token used in `staticman.yml` in the config.

--- a/README.md
+++ b/README.md
@@ -106,3 +106,9 @@ Example:
 3. Update the templates in `templates` according to your preferences (or go with the default ones).
 4. Make sure that there's a `_posts` and `_stats` folder in your git repository.
 4. You should be good to go now and git support should be active on the next startup. You can now use the `postsolves` command to push blog posts with the current solve status to git.
+
+
+## Using Link saver
+
+1. Setup a github repo with jekyll and staticman (e.g. https://github.com/ujjwal96/links)
+2. Set GITHUB_REPO (owner/repo-name) and GITHUB_BRANCH (master) variables in `save_handler.py`

--- a/README.md
+++ b/README.md
@@ -110,5 +110,6 @@ Example:
 
 ## Using Link saver
 
-1. Setup a github repo with jekyll and staticman (e.g. https://github.com/ujjwal96/links)
-2. Set GITHUB_REPO (owner/repo-name) and GITHUB_BRANCH (master) variables in `save_handler.py`
+1. Setup a github repo with jekyll and staticman (e.g. https://github.com/ujjwal96/links).
+2. Copy `config_savelink.json.template` to `config_savelink.json`.
+3. Configure the git repo and branch to be used.

--- a/bottypes/command.py
+++ b/bottypes/command.py
@@ -7,4 +7,4 @@ class Command(ABC):
     def __init__(self): pass
 
     @classmethod
-    def execute(cls, slack_client, args, channel_id, user, user_is_admin): pass
+    def execute(cls, slack_client, args, timestamp, channel_id, user, user_is_admin): pass

--- a/config_savelink.json.template
+++ b/config_savelink.json.template
@@ -1,0 +1,4 @@
+{
+  "git_repo": "user/repo",
+  "git_branch": "master"
+}

--- a/config_savelink.json.template
+++ b/config_savelink.json.template
@@ -1,5 +1,6 @@
 {
   "git_repo": "user/repo",
   "git_branch": "master",
-  "staticman-token": ""
+  "staticman-token": "",
+  "allowed_users": []
 }

--- a/config_savelink.json.template
+++ b/config_savelink.json.template
@@ -1,4 +1,5 @@
 {
   "git_repo": "user/repo",
-  "git_branch": "master"
+  "git_branch": "master",
+  "staticman-token": ""
 }

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -3,5 +3,6 @@ __all__ = [
     "syscalls_handler",
     "bot_handler",
     "admin_handler",
-    "wolfram_handler"
+    "wolfram_handler",
+    "save_handler"
 ]

--- a/handlers/save_handler.py
+++ b/handlers/save_handler.py
@@ -24,6 +24,7 @@ class SaveCommand(Command):
             raise InvalidCommand("Invalid Category.")
 
         message = slack_wrapper.get_message(channel_id, timestamp)["messages"][0]["text"]
+        profile_details = slack_wrapper.get_member(user_id)["user"]["profile"]
         url_regex = "((https?):\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?"
         url = re.search(url_regex, message)
 
@@ -40,7 +41,8 @@ class SaveCommand(Command):
             "fields[excerpt]": url_data["desc"],
             "fields[category]": args[0],
             "fields[content]": url_data["content"],
-            "fields[header][overlay_image]": url_data["img"]
+            "fields[header][overlay_image]": url_data["img"],
+            "fields[user]": profile_details["display_name"] or profile_details["real_name"]
         }
         resp = requests.post(
             "https://mystaticmanapp.herokuapp.com/v2/entry/{git_repo}/{git_branch}/links".format_map(

--- a/handlers/save_handler.py
+++ b/handlers/save_handler.py
@@ -1,0 +1,70 @@
+import re
+
+import requests
+
+from bottypes.command_descriptor import *
+import handlers.handler_factory as handler_factory
+from handlers.base_handler import *
+from util.savelinkhelper import unfurl
+
+GITHUB_REPO = ""  # owner/repo-name
+GITHUB_BRANCH = ""  # e.g master
+
+CATEGORIES = ["web", "pwn", "re", "crypto", "misc"]
+
+
+class SaveCommand(Command):
+    """Save a url from a slack message according to a specific category"""
+
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        """Execute the save link command"""
+        if not GITHUB_REPO and not GITHUB_BRANCH:
+            raise InvalidCommand("Link saver not configured")
+        if args[0] not in CATEGORIES:
+            raise InvalidCommand("Invalid Category")
+
+        message = slack_wrapper.get_message(channel_id, timestamp)["messages"][0]["text"]
+        url_regex = "((https?):\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?"
+        url = re.search(url_regex, message)
+
+        if not url:
+            slack_wrapper.post_message(channel_id, "Couldn't extract URL", timestamp)
+            return
+
+        url_data = unfurl(url.group())
+
+        data = {
+            "fields[title]": url_data["title"],
+            "fields[link]": url.group(),
+            "fields[description]": url_data["desc"],
+            "fields[category]": "{}".format(args[0])
+        }
+        resp = requests.post(
+            "https://dev.staticman.net/v3/entry/github/{}/{}/links".format(
+                GITHUB_REPO,
+                GITHUB_BRANCH
+            ),
+            data=data
+        ).json()
+
+        if resp["success"]:
+            slack_wrapper.post_message(channel_id, "Link saved successfully", timestamp)
+        else:
+            slack_wrapper.post_message(channel_id, "Error saving the link: `{}`".format(resp), timestamp)
+
+
+class SaveHandler(BaseHandler):
+    """Handler for saving links"""
+
+    def __init__(self):
+        self.commands = {
+            "link": CommandDesc(
+                SaveCommand,
+                "Save a link in one of the categories: {}".format(", ".join(CATEGORIES)),
+                ["category"], None
+            ),
+        }
+
+
+handler_factory.register("save", SaveHandler())

--- a/handlers/save_handler.py
+++ b/handlers/save_handler.py
@@ -5,7 +5,7 @@ import requests
 from bottypes.command_descriptor import *
 import handlers.handler_factory as handler_factory
 from handlers.base_handler import *
-from util.savelinkhelper import unfurl, GITHUB_BRANCH, GITHUB_REPO
+from util.savelinkhelper import unfurl, SAVE_CONFIG, SAVE_SUPPORT
 from util.loghandler import log
 
 CATEGORIES = ["web", "pwn", "re", "crypto", "misc"]
@@ -18,7 +18,7 @@ class SaveCommand(Command):
     def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
         """Execute the save command."""
 
-        if not GITHUB_REPO or not GITHUB_BRANCH:
+        if not SAVE_SUPPORT:
             raise InvalidCommand("Link saver not configured.")
         if args[0] not in CATEGORIES:
             raise InvalidCommand("Invalid Category.")
@@ -34,20 +34,17 @@ class SaveCommand(Command):
         url_data = unfurl(url.group())
 
         data = {
+            "options[staticman-token]": SAVE_CONFIG["staticman-token"],
             "fields[title]": url_data["title"],
             "fields[link]": url.group(),
             "fields[excerpt]": url_data["desc"],
             "fields[category]": args[0],
-
-            # https://github.com/eduardoboucas/staticman/issues/267
-            "fields[content]": "{} ...".format(url_data["content"][:10000]),
-
+            "fields[content]": url_data["content"],
             "fields[header][overlay_image]": url_data["img"]
         }
         resp = requests.post(
-            "https://dev.staticman.net/v3/entry/github/{}/{}/links".format(
-                GITHUB_REPO,
-                GITHUB_BRANCH
+            "https://mystaticmanapp.herokuapp.com/v2/entry/{git_repo}/{git_branch}/links".format_map(
+                SAVE_CONFIG
             ),
             data=data
         ).json()

--- a/handlers/save_handler.py
+++ b/handlers/save_handler.py
@@ -19,9 +19,11 @@ class SaveCommand(Command):
         """Execute the save command."""
 
         if not SAVE_SUPPORT:
-            raise InvalidCommand("Link saver not configured.")
+            raise InvalidCommand("Save Link failed: Link saver not configured.")
         if args[0] not in CATEGORIES:
-            raise InvalidCommand("Invalid Category.")
+            raise InvalidCommand("Save Link failed: Invalid Category.")
+        if SAVE_CONFIG["allowed_users"] and user_id not in SAVE_CONFIG["allowed_users"]:
+            raise InvalidCommand("Save Link failed: User not allowed to save links")
 
         message = slack_wrapper.get_message(channel_id, timestamp)["messages"][0]["text"]
         profile_details = slack_wrapper.get_member(user_id)["user"]["profile"]
@@ -29,7 +31,7 @@ class SaveCommand(Command):
         url = re.search(url_regex, message)
 
         if not url:
-            slack_wrapper.post_message(channel_id, "Error: `Unable to extract URL`", timestamp)
+            slack_wrapper.post_message(channel_id, "Save Link failed: Unable to extract URL", timestamp)
             return
 
         url_data = unfurl(url.group())

--- a/handlers/save_handler.py
+++ b/handlers/save_handler.py
@@ -5,31 +5,30 @@ import requests
 from bottypes.command_descriptor import *
 import handlers.handler_factory as handler_factory
 from handlers.base_handler import *
-from util.savelinkhelper import unfurl
-
-GITHUB_REPO = ""  # owner/repo-name
-GITHUB_BRANCH = ""  # e.g master
+from util.savelinkhelper import unfurl, GITHUB_BRANCH, GITHUB_REPO
+from util.loghandler import log
 
 CATEGORIES = ["web", "pwn", "re", "crypto", "misc"]
 
 
 class SaveCommand(Command):
-    """Save a url from a slack message according to a specific category"""
+    """Save a url from a slack message according to a specific category."""
 
     @classmethod
     def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
-        """Execute the save link command"""
-        if not GITHUB_REPO and not GITHUB_BRANCH:
-            raise InvalidCommand("Link saver not configured")
+        """Execute the save command."""
+
+        if not GITHUB_REPO or not GITHUB_BRANCH:
+            raise InvalidCommand("Link saver not configured.")
         if args[0] not in CATEGORIES:
-            raise InvalidCommand("Invalid Category")
+            raise InvalidCommand("Invalid Category.")
 
         message = slack_wrapper.get_message(channel_id, timestamp)["messages"][0]["text"]
         url_regex = "((https?):\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?"
         url = re.search(url_regex, message)
 
         if not url:
-            slack_wrapper.post_message(channel_id, "Couldn't extract URL", timestamp)
+            slack_wrapper.post_message(channel_id, "Error: `Unable to extract URL`", timestamp)
             return
 
         url_data = unfurl(url.group())
@@ -37,8 +36,13 @@ class SaveCommand(Command):
         data = {
             "fields[title]": url_data["title"],
             "fields[link]": url.group(),
-            "fields[description]": url_data["desc"],
-            "fields[category]": "{}".format(args[0])
+            "fields[excerpt]": url_data["desc"],
+            "fields[category]": args[0],
+
+            # https://github.com/eduardoboucas/staticman/issues/267
+            "fields[content]": "{} ...".format(url_data["content"][:10000]),
+
+            "fields[header][overlay_image]": url_data["img"]
         }
         resp = requests.post(
             "https://dev.staticman.net/v3/entry/github/{}/{}/links".format(
@@ -51,11 +55,12 @@ class SaveCommand(Command):
         if resp["success"]:
             slack_wrapper.post_message(channel_id, "Link saved successfully", timestamp)
         else:
-            slack_wrapper.post_message(channel_id, "Error saving the link: `{}`".format(resp), timestamp)
+            slack_wrapper.post_message(channel_id, "Error saving the link", timestamp)
+            log.error(resp)
 
 
 class SaveHandler(BaseHandler):
-    """Handler for saving links"""
+    """Handler for saving links."""
 
     def __init__(self):
         self.commands = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astroid==2.0.4
+beautifulsoup4==4.7.1
 certifi==2018.10.15
 chardet==3.0.4
 dulwich==0.19.6

--- a/util/savelinkhelper.py
+++ b/util/savelinkhelper.py
@@ -1,0 +1,34 @@
+"""Helper module for save_handler to fetch details of a url."""
+import re
+import requests
+from bs4 import BeautifulSoup
+
+
+def get_title(soup: BeautifulSoup):
+    title = soup.find("meta", property=re.compile("title", re.I)) or \
+            soup.find("meta", attrs={"name": re.compile("title", re.I)})
+    if title:
+        title = title["content"]
+    else:
+        title = soup.title.string
+
+    title = title.replace("|", "-")
+    return title.strip()
+
+
+def get_desc(soup: BeautifulSoup):
+    desc = soup.find("meta", property=re.compile("desc", re.I)) or \
+           soup.find("meta", attrs={"name": re.compile("desc", re.I)})
+    if desc:
+        return desc["content"].strip()
+    else:
+        return ""
+
+
+def unfurl(url: str):
+    details = {}
+    resp = requests.get(url).text
+    soup = BeautifulSoup(resp, "html.parser")
+    details["title"] = get_title(soup)
+    details["desc"] = get_desc(soup)
+    return details

--- a/util/savelinkhelper.py
+++ b/util/savelinkhelper.py
@@ -39,17 +39,17 @@ def get_content(url: str):
 
 
 def unfurl(url: str):
-    details = {
-        "title": "",
-        "desc": "",
-        "content": "",
-        "img": ""
-    }
     resp = requests.get(url).text
     soup = BeautifulSoup(resp, "html.parser")
-    details["title"] = get_title(soup)
-    details["desc"] = get_desc(soup)
-    details["content"], details["img"] = get_content(url)
+    content, img = get_content(url)
+
+    details = {
+        "title": get_title(soup),
+        "desc": get_desc(soup),
+        "content": content,
+        "img": img
+    }
+
     return details
 
 
@@ -58,10 +58,10 @@ def init_savelink_config():
     try:
         with open("./config_savelink.json") as f:
             conf = json.load(f)
-            return conf["git_repo"], conf["git_branch"]
+            return conf, True
     except (IOError, FileNotFoundError) as e:
         log.info("Save handler configuration couldn't be loaded: {}.".format(e))
-        return None, None
+        return None, False
 
 
-GITHUB_REPO, GITHUB_BRANCH = init_savelink_config()
+SAVE_CONFIG, SAVE_SUPPORT = init_savelink_config()


### PR DESCRIPTION
This PR adds a save links handler which can be used to save links shared in slack.
To setup - You can fork or copy the files from https://github.com/ujjwal96/links (also follow the readme steps there) to OTA org on github and edit the variables `GITHUB_REPO`, `GITHUB_BRANCH` in `save_handler.py`  
To save links users can comment `!link <category>` on any message containing a URL.

Demo - https://ujjwal96.github.io/links/