### PR TITLE
Remove URL from creds to get more space in purpose

### DIFF
--- a/bottypes/ctf.py
+++ b/bottypes/ctf.py
@@ -11,8 +11,7 @@ class CTF:
         self.name = name
         self.challenges = []
         self.cred_user = ""
-        self.cred_pw = ""
-        self.cred_url = ""
+        self.cred_pw = ""        
         self.long_name = long_name
         self.finished = False
 

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -753,15 +753,19 @@ class AddCredsCommand(Command):
         def update_func(ctf):
             ctf.cred_user = args[0]
             ctf.cred_pw = args[1]
-            ctf.cred_url = args[2] if len(args) > 2 else ""
+            
 
         # Update database
         ctf = update_ctf(ChallengeHandler.DB, cur_ctf.channel_id, update_func)
 
         if ctf:
             ChallengeHandler.update_ctf_purpose(slack_wrapper, ctf)
-            if ctf.cred_url:
-                slack_wrapper.set_topic(channel_id, ctf.cred_url)
+
+            ctf_cred_url = args[2] if len(args) > 2 else ""
+
+            if ctf_cred_url:
+                slack_wrapper.set_topic(channel_id, ctf_cred_url)
+
             message = "Credentials for CTF *{}* updated...".format(ctf.name)
             slack_wrapper.post_message(channel_id, message)
 
@@ -780,10 +784,6 @@ class ShowCredsCommand(Command):
         if cur_ctf.cred_user and cur_ctf.cred_pw:
             message = "Credentials for CTF *{}*\n".format(cur_ctf.name)
             message += "```"
-
-            if cur_ctf.cred_url:
-                message += "URL      : {}\n".format(cur_ctf.cred_url)
-
             message += "Username : {}\n".format(cur_ctf.cred_user)
             message += "Password : {}\n".format(cur_ctf.cred_pw)
             message += "```"
@@ -813,18 +813,17 @@ class ChallengeHandler(BaseHandler):
 
     DB = "databases/challenge_handler.bin"
     CTF_PURPOSE = {
-        "ota_bot": "DO_NOT_DELETE_THIS",
+        "ota_bot": "OTABOT",
         "name": "",
         "type": "CTF",
         "cred_user": "",
-        "cred_pw": "",
-        "cred_url": "",
+        "cred_pw": "",        
         "long_name": "",
         "finished": False
     }
 
     CHALL_PURPOSE = {
-        "ota_bot": "DO_NOT_DELETE_THIS",
+        "ota_bot": "OTABOT",
         "ctf_id": "",
         "name": "",
         "solved": "",
@@ -865,12 +864,11 @@ class ChallengeHandler(BaseHandler):
         Update the purpose for the ctf channel.
         """
         purpose = dict(ChallengeHandler.CTF_PURPOSE)
-        purpose["ota_bot"] = "DO_NOT_DELETE_THIS"
+        purpose["ota_bot"] = "OTABOT"
         purpose["name"] = ctf.name
         purpose["type"] = "CTF"
         purpose["cred_user"] = ctf.cred_user
-        purpose["cred_pw"] = ctf.cred_pw
-        purpose["cred_url"] = ctf.cred_url
+        purpose["cred_pw"] = ctf.cred_pw        
         purpose["long_name"] = ctf.long_name
         purpose["finished"] = ctf.finished
 
@@ -893,8 +891,7 @@ class ChallengeHandler(BaseHandler):
                 ctf = CTF(channel['id'], purpose['name'], purpose['long_name'])
 
                 ctf.cred_user = purpose.get("cred_user", "")
-                ctf.cred_pw = purpose.get("cred_pw", "")
-                ctf.cred_url = purpose.get("cred_url", "")
+                ctf.cred_pw = purpose.get("cred_pw", "")                
                 ctf.finished = purpose.get("finished", False)
 
                 database[ctf.channel_id] = ctf

--- a/tests/testfiles/get_private_channels_response_default.json
+++ b/tests/testfiles/get_private_channels_response_default.json
@@ -19,7 +19,7 @@
                 "last_set": 0
             },
             "purpose": {
-                "value": "{\"ota_bot\": \"DO_NOT_DELETE_THIS\", \"ctf_id\": \"UNITTEST_CHANNEL_ID1\", \"name\": \"pwn1\", \"solved\": [\"someone\"], \"category\": \"pwn\", \"type\": \"CHALLENGE\", \"solve_date\":1533056159}",
+                "value": "{\"ota_bot\": \"OTABOT\", \"ctf_id\": \"UNITTEST_CHANNEL_ID1\", \"name\": \"pwn1\", \"solved\": [\"someone\"], \"category\": \"pwn\", \"type\": \"CHALLENGE\", \"solve_date\":1533056159}",
                 "creator": "UNITTEST_USER_ID1",
                 "last_set": 1533056159
             },
@@ -43,7 +43,7 @@
                 "last_set": 0
             },
             "purpose": {
-                "value": "{\"ota_bot\": \"DO_NOT_DELETE_THIS\", \"ctf_id\": \"UNITTEST_CHANNEL_ID1\", \"name\": \"pwn2\", \"solved\": \"\", \"category\": \"pwn\", \"type\": \"CHALLENGE\"}",
+                "value": "{\"ota_bot\": \"OTABOT\", \"ctf_id\": \"UNITTEST_CHANNEL_ID1\", \"name\": \"pwn2\", \"solved\": \"\", \"category\": \"pwn\", \"type\": \"CHALLENGE\"}",
                 "creator": "UNITTEST_USER_ID1",
                 "last_set": 1533056149
             },

--- a/tests/testfiles/get_public_channels_response_default.json
+++ b/tests/testfiles/get_public_channels_response_default.json
@@ -25,7 +25,7 @@
                 "last_set": 0
             },
             "purpose": {
-                "value": "{\"ota_bot\": \"DO_NOT_DELETE_THIS\", \"name\": \"ctf1\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"cred_url\": \"\", \"long_name\": \"createfix\"}",
+                "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"ctf1\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
                 "creator": "UNITTEST_USER_ID1",
                 "last_set": 1532537813
             },
@@ -56,7 +56,7 @@
                 "last_set": 0
             },
             "purpose": {
-                "value": "{\"ota_bot\": \"DO_NOT_DELETE_THIS\", \"name\": \"createfix\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"cred_url\": \"\", \"long_name\": \"createfix\"}",
+                "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"createfix\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
                 "creator": "UNITTEST_USER_ID1",
                 "last_set": 1532537813
             },


### PR DESCRIPTION
We have to shorten the purpose, since there's a max size limit.

Long ctf name together with url occasionally brings the purpose size over this limit, so otabot will not be able to update the purpose with the credentials (only updating local db).

If the bot has to restart during the ctf, credentials will be lost due to this (since he reinitializes them from the purpose).

But since we put the ctf url in the ctf channel topic anyways, this isn't a real loss, but will result in not losing credentials so easily.