### PR TITLE
Don't allow links in ctf long name

### DIFF
--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -39,6 +39,10 @@ class AddCTFCommand(Command):
         name = args[0].lower()
         long_name = " ".join(args[1:])
 
+        # Don't allow incorrectly parsed long names
+        if "<http" in long_name:
+            raise InvalidCommand("Add CTF failed: Long name interpreted as link, try avoid using `.` in it.")
+
         if len(name) > 10:
             raise InvalidCommand("Add CTF failed: CTF name must be <= 10 characters.")
 


### PR DESCRIPTION
Fixes #200 

Since any argument for ctf long name will already be interpreted as an url (if it contains one or two dots), before we even receive the command in the bot, the only way to get around this, seems to be, to check, if the long name shows up as an url, and then just disallow ctf creation. 

This way, people aren't able to create the ctf, before fixing the long name.