### PR TITLE
Add support for private CTF channels

### DIFF
--- a/backend/DESIGN.md
+++ b/backend/DESIGN.md
@@ -1,0 +1,25 @@
+
+#### abstract DAO describes the serializations supported by the backend
+
+```python
+class CtfDao:
+    pass
+
+class ChallengeDao:
+    pass
+```
+
+#### concrete DAO implement serialization described by abstract DAO
+
+
+#### application receives handle to backend at startup
+
+
+#### ctf/challenge objects are initialized with instance of concrete dao
+
+#### backend receives serialized DAO and persists it
+                    ┌───> PostgreSQL
++---------+         ├───> Redis
+| Backend |>────────┼───> Pickle
++---------+         └───> ...
+

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,0 +1,15 @@
+class Backend:
+    def __init__(self):
+        pass
+
+    def create(self):
+        pass
+
+    def read(self):
+        pass
+
+    def update(self):
+        pass
+
+    def destroy(self):
+        pass

--- a/backend/pickle.py
+++ b/backend/pickle.py
@@ -1,0 +1,2 @@
+class Pickle(Backend):
+    pass

--- a/backend/redis.py
+++ b/backend/redis.py
@@ -1,0 +1,2 @@
+class Redis(Backend):
+    pass

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -95,6 +95,10 @@ class AddCTFCommand(Command):
     @classmethod
     def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
         """Execute AddCTF command."""
+
+        # Pull options out into its own array
+        opts, args = parse_opts(args)
+
         name = args[0].lower()
         long_name = " ".join(args[1:])
 
@@ -110,7 +114,8 @@ class AddCTFCommand(Command):
             raise InvalidCommand("Add CTF failed: Invalid characters for CTF name found.")
 
         # Create the channel
-        response = slack_wrapper.create_channel(name)
+        is_private = True if 'private' in opts else False
+        response = slack_wrapper.create_channel(name, is_private)
 
         # Validate that the channel was successfully created.
         if not response['ok']:

--- a/util/util.py
+++ b/util/util.py
@@ -1,12 +1,29 @@
 import json
 import pickle
 import re
+from string import punctuation
 
 from bottypes.invalid_command import InvalidCommand
 
 #######
 # Helper functions
 #######
+
+def parse_opts(_args):
+    """
+    Filter an array of args and extract those beginning with a hyphen into a
+    new array called opts, removing any/all leading punctuation in the process.
+    Return a 2-tuple like ([opts], [args])
+    """
+    opts = []
+    args = []
+    for arg in _args:
+        if arg.startswith('-'):
+            arg = arg.strip(punctuation)
+            opts.append(arg)
+        else:
+            args.append(arg)
+    return (opts,args)
 
 
 def load_json(string):


### PR DESCRIPTION
Fix issue #125 

Add util method for parsing args for options. This method takes an array and searches for any strings in that array beginning with a hyphen. If it encounters such a string it strips the leading punctuation from that string and puts it into a new array. After iterating the given array it returns a 2-tuple containing the new array of options sans leading punctuation and the original array minus those extracted options.