### PR TITLE
Enable push via ssh when pass is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ Example:
 }
 ```
 
+Alternatively, you may decide to omit the "git_repopass" entry. In such an event (or if the entry is left blank) then the handler will attempt to push to the configured "git_remoteuri" using the `git` protocol, including using any SSH identities you may have configured.
+Note: If you configure the solvetracker this way, you need to make sure you are using an SSH identity without a passphrase.
+
 3. Update the templates in `templates` according to your preferences (or go with the default ones).
 4. Make sure that there's a `_posts` and `_stats` folder in your git repository.
-4. You should be good to go now and git support should be active on the next startup. You can now use the `postsolves` command to push blog posts with the current solve status to git.
+5. You should be good to go now and git support should be active on the next startup. You can now use the `postsolves` command to push blog posts with the current solve status to git.
 
 
 ## Using Link saver

--- a/util/githandler.py
+++ b/util/githandler.py
@@ -48,8 +48,15 @@ class GitHandler():
     def push(self, repo_user, repo_pass, repo_remote, repo_branch):
         """Push the current commit to git."""
         try:
-            porcelain.push(self.repo, "https://{}:{}@{}".format(repo_user,
-                                                                repo_pass, repo_remote), bytes(repo_branch, "utf-8"))
+            if repo_pass:
+                porcelain.push(self.repo,
+                        "https://{}:{}@{}".format(repo_user, repo_pass, repo_remote),
+                        bytes(repo_branch, "utf-8"))
+            else:
+                porcelain.push(self.repo, 
+                        "git@{}".format(repo_remote), 
+                        bytes(repo_branch, "utf-8"))
+
         except dulwich.errors.GitProtocolError:
             raise InvalidCommand(
                 "Upload file failed: GitProtocolError - Check your username and password in the git configuration...")

--- a/util/solveposthelper.py
+++ b/util/solveposthelper.py
@@ -25,17 +25,17 @@ def post_ctf_data(ctf, title):
         stat_data = resolve_stats_template(ctf)
         stat_filename = "_stats/{}.json".format(ctf.name)
 
-        git = GitHandler(ST_GIT_CONFIG["git_repopath"])
+        git = GitHandler(ST_GIT_CONFIG.get("git_repopath"))
 
         git.add_file(post_data, post_filename)
         git.add_file(stat_data, stat_filename)
 
         git.commit("Solve post from {}".format(ctf.name))
 
-        git.push(ST_GIT_CONFIG["git_repouser"], ST_GIT_CONFIG["git_repopass"],
-                 ST_GIT_CONFIG["git_remoteuri"], ST_GIT_CONFIG["git_branch"])
+        git.push(ST_GIT_CONFIG.get("git_repouser"), ST_GIT_CONFIG.get("git_repopass"),
+                 ST_GIT_CONFIG.get("git_remoteuri"), ST_GIT_CONFIG.get("git_branch"))
 
-        return ST_GIT_CONFIG["git_baseurl"]
+        return ST_GIT_CONFIG.get("git_baseurl")
 
     except InvalidCommand as invalid_cmd:
         # Just pass invalid commands on


### PR DESCRIPTION
Enable ssh push to github for the solve tracker.

This patch adds a check to see if a password was supplied for the github user in the solve tracker config and, if none was supplied, attempts to do the push via SSH instead.