### PR TITLE
Fix bug with `!solve` dropping additional solvers

### DIFF
--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -22,7 +22,7 @@ class AddChallengeTagCommand(Command):
     def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
 
         tags = None
-        challenge = get_challenge_from_args(ChallengeHandler.DB, args, channel_id)
+        challenge = get_challenge_from_args_or_channel(ChallengeHandler.DB, args, channel_id)
 
         if challenge.channel_id == channel_id:
             # We were called from the Challenge channel
@@ -50,7 +50,7 @@ class RemoveChallengeTagCommand(Command):
     def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
 
         tags = None
-        challenge = get_challenge_from_args(ChallengeHandler.DB, args, channel_id)
+        challenge = get_challenge_from_args_or_channel(ChallengeHandler.DB, args, channel_id)
 
         if challenge.channel_id == channel_id:
             # We were called from the Challenge channel

--- a/util/util.py
+++ b/util/util.py
@@ -119,9 +119,36 @@ def get_challenge_by_name(database, challenge_name, ctf_channel_id):
     return None
 
 
+def get_challenge_from_args_or_channel(database, args, channel_id):
+    """
+    Helper method for getting a Challenge either from arguments or current channel.
+    Return the corresponding Challenge if called from a challenge channel.
+    Return the Challenge corresponding to the first argument if called from the
+    CTF channel.
+    Return None if no Challenge can be found.
+    """
+
+    # Check if we're currently in a challenge channel
+    current_chal = get_challenge_by_channel_id(database, channel_id)
+
+    if current_chal:
+        # User is in the challenge channel
+        challenge = current_chal
+    else:
+        # Assume user is in the ctf channel
+        try:
+            challenge_name = args[0].lower().strip("*")
+            challenge = get_challenge_by_name(database, challenge_name, channel_id)
+        except IndexError:
+            challenge = None
+
+    return challenge
+
+
 def get_challenge_from_args(database, args, channel_id):
     """
     Helper method for getting a Challenge either from arguments or current channel.
+    Return None if called from a Challenge channel.
     """
     # Multiple arguments: Need to check if a challenge was specified or not
     challenge_name = args[0].lower().strip("*")
@@ -130,8 +157,9 @@ def get_challenge_from_args(database, args, channel_id):
     current_chal = get_challenge_by_channel_id(database, channel_id)
 
     if current_chal:
-        # User is in the challenge channel
-        return current_chal
+        # User is in a challenge channel => Check for challenge by name
+        # in parent ctf channel
+        challenge = get_challenge_by_name(database, challenge_name, current_chal.ctf_channel_id)
     else:
         # User is in the ctf channel => Check for challenge by name in
         # current challenge


### PR DESCRIPTION
#### Problem
The `!solve` command is currently dropping the first additional solver, if present, when the command is called from within the challenge channel. It's working as expected in all other invocation contexts. See screenshot below.

_Incorrect - drops first additional solver_

![bug_solve+1_n-chall](https://user-images.githubusercontent.com/3689038/83935625-58c6c080-a789-11ea-9f1b-587e52654355.png)

_Incorrect - drops first and keeps second additional solver_

![bug_solve+2_n-chall](https://user-images.githubusercontent.com/3689038/83935700-ee625000-a789-11ea-93c4-79ad11392b30.png)

_Correct - called from within CTF channel, retains first additional solver_

![bug_solve+1_n-ctf](https://user-images.githubusercontent.com/3689038/83935795-071f3580-a78b-11ea-8350-eaeb39ba5900.png)

_Correct - called from within CTF channel, retains first and second additional solvers_

![bug_solve+2_n-ctf](https://user-images.githubusercontent.com/3689038/83935815-29b14e80-a78b-11ea-8b19-a9d34a59ffbf.png)

#### Solution

This patch corrects a logic error causing the first arg to be sliced off when !solve is called from within a challenge channel. 

_Corrected scenarios_
![fix_solve+1_n-chall](https://user-images.githubusercontent.com/3689038/83935850-8280e700-a78b-11ea-86d6-83bd33cb4911.png)
![fix_solve+2_n-chall](https://user-images.githubusercontent.com/3689038/83935855-844aaa80-a78b-11ea-95f1-e865147b6da0.png)
![fix_solve+1_n-ctf](https://user-images.githubusercontent.com/3689038/83935856-86146e00-a78b-11ea-8340-4934ad669961.png)
![fix_solve+2_n-ctf](https://user-images.githubusercontent.com/3689038/83935860-8e6ca900-a78b-11ea-8e1d-83e24d858ce7.png)






