### PR TITLE
Group the CTFs in the status command by finished status

### DIFF
--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -15,6 +15,7 @@ from util.loghandler import log
 from util.solveposthelper import ST_GIT_SUPPORT, post_ctf_data
 from util.util import *
 
+
 class AddChallengeTagCommand(Command):
     """Add a tag or tags to a challenge"""
 
@@ -42,6 +43,7 @@ class AddChallengeTagCommand(Command):
             # Save challenge iff it was modified
             if dirty:
                 save_challenge(ChallengeHandler.DB, challenge)
+
 
 class RemoveChallengeTagCommand(Command):
     """Remove a tag or tags from a challenge"""
@@ -71,6 +73,7 @@ class RemoveChallengeTagCommand(Command):
             if dirty:
                 save_challenge(ChallengeHandler.DB, challenge)
 
+
 class RollCommand(Command):
     """Roll the dice. ;)"""
 
@@ -86,8 +89,10 @@ class RollCommand(Command):
 
         slack_wrapper.post_message(channel_id, message)
 
+
 MAX_CHANNEL_NAME_LENGTH = 80
 MAX_CTF_NAME_LENGTH = 40
+
 
 class AddCTFCommand(Command):
     """Add and keep track of a new CTF."""
@@ -404,19 +409,32 @@ class StatusCommand(Command):
     @classmethod
     def build_short_status(cls, ctf_list):
         """Build short status list."""
-        response = ""
+        finished_response = ""
+        running_response = ""
 
-        for ctf in ctf_list:
+        def get_ctf_status(ctf, append=""):
             # Build short status list
             solved = [c for c in ctf.challenges if c.is_solved]
+            return "*#{} : _{}_ [{} solved / {} total] {}*\n".format(
+                ctf.name, ctf.long_name, len(solved), len(ctf.challenges), append)
 
-            def get_finish_info(ctf):
-                return "(finished {} ago)".format(cls.get_finished_string(ctf)) if ctf.finished_on else "(finished)"
+        for ctf in ctf_list:
+            if ctf.finished:
+                finish_info = "(finished {} ago)".format(cls.get_finished_string(ctf)) if ctf.finished_on else "(finished)"
+                finished_response += get_ctf_status(ctf, finish_info)
+            else:
+                running_response += get_ctf_status(ctf)
 
-            response += "*#{} : _{}_ [{} solved / {} total] {}*\n".format(
-                ctf.name, ctf.long_name, len(solved), len(ctf.challenges), get_finish_info(ctf) if ctf.finished else "")
+        running_response = running_response.strip()
+        finished_response = finished_response.strip()
 
-        response = response.strip()
+        if running_response != "":
+            running_response = "*Current CTFs:*\n{}".format(running_response)
+
+        if finished_response != "":
+            finished_response = "*Finished CTFs:*\n{}".format(finished_response)
+
+        response = "{}\n{}".format(running_response, finished_response)
 
         if response == "":  # Response is empty
             response += "*There are currently no running CTFs*"
@@ -495,11 +513,11 @@ class StatusCommand(Command):
                             players.append(members[player_id])
 
                     response += "[{} active] *{}* {}: {} {}\n".  format(
-                            len(players),
-                            challenge.name,
-                            "[{}]".format(", ".join(challenge.tags)) if len(challenge.tags) > 0 else "",
-                            "({})".format(challenge.category) if challenge.category else "",
-                            transliterate(", ".join(players)))
+                        len(players),
+                        challenge.name,
+                        "[{}]".format(", ".join(challenge.tags)) if len(challenge.tags) > 0 else "",
+                        "({})".format(challenge.category) if challenge.category else "",
+                        transliterate(", ".join(players)))
         response = response.strip()
 
         if response == "":  # Response is empty

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -395,7 +395,8 @@ class UpdateShortStatusCommand(Command):
         result = slack_wrapper.get_message(channel_id, timestamp)
 
         if result["ok"] and result["messages"]:
-            if "solved /" in result["messages"][0]["text"]:
+            text = result["messages"][0]["text"]
+            if "solved /" in text or "no running CTFs" in text:
                 status, _ = StatusCommand().build_status_message(slack_wrapper, None, channel_id, user_id, user_is_admin, False)
 
                 slack_wrapper.update_message(channel_id, timestamp, status)
@@ -434,7 +435,7 @@ class StatusCommand(Command):
         if finished_response != "":
             finished_response = "*Finished CTFs:*\n{}".format(finished_response)
 
-        response = "{}\n{}".format(running_response, finished_response)
+        response = "\n\n".join([resp for resp in [running_response, finished_response] if resp])
 
         if response == "":  # Response is empty
             response += "*There are currently no running CTFs*"

--- a/runtests.py
+++ b/runtests.py
@@ -37,10 +37,10 @@ class BotBaseTest(TestCase):
     def create_slack_wrapper_mock(self, api_key):
         return SlackWrapperMock(api_key)
 
-    def exec_command(self, msg, exec_user="normal_user"):
+    def exec_command(self, msg, exec_user="normal_user", channel="UNITTESTCHANNELID"):
         """Simulate execution of the specified message as the specified user in the test environment."""
         testmsg = [{'type': 'message', 'user': exec_user, 'text': msg, 'client_msg_id': '738e4beb-d50e-42a4-a60e-3fafd4bd71da',
-                    'team': 'UNITTESTTEAMID', 'channel': 'UNITTESTCHANNELID', 'event_ts': '1549715670.002000', 'ts': '1549715670.002000'}]
+                    'team': 'UNITTESTTEAMID', 'channel': channel, 'event_ts': '1549715670.002000', 'ts': '1549715670.002000'}]
         self.botserver.handle_message(testmsg)
 
     def exec_reaction(self, reaction, exec_user="normal_user"):
@@ -56,6 +56,7 @@ class BotBaseTest(TestCase):
     def check_for_response(self, expected_result):
         """ Check if the simulated slack responses contain an expected result. """
         for msg in self.botserver.slack_wrapper.message_list:
+            print(msg.message)
             if expected_result in msg.message:
                 return True
 
@@ -150,7 +151,7 @@ class TestAdminHandler(BotBaseTest):
 class TestChallengeHandler(BotBaseTest):
     def test_addctf_name_too_long(self):
         ctf_name = "unittest_{}".format("A"*50)
-        
+
         self.exec_command("!ctf addctf {} unittest_ctf".format(ctf_name))
 
         self.assertTrue(self.check_for_response_available(),
@@ -203,6 +204,10 @@ class TestChallengeHandler(BotBaseTest):
 
         self.assertTrue(self.check_for_response_available(),
                         msg="Bot didn't react on unit test. Check for possible exceptions.")
+        self.assertTrue(self.check_for_response("Current CTFs"),
+                        msg="Staus command didn't return the correct response")
+        self.assertTrue(self.check_for_response("Finished CTFs"),
+                        msg="Staus command didn't return the correct response")
         self.assertFalse(self.check_for_response("Unknown handler or command"),
                          msg="Status command didn't execute properly.")
 

--- a/tests/testfiles/get_public_channels_response_default.json
+++ b/tests/testfiles/get_public_channels_response_default.json
@@ -1,67 +1,92 @@
 {
-    "ok": true,
-    "channels": [
-        {
-            "id": "UNITTEST_CHANNEL_ID1",
-            "name": "ctf1",
-            "is_channel": true,
-            "created": 1532537813,
-            "is_archived": false,
-            "is_general": false,
-            "unlinked": 0,
-            "creator": "UNITTEST_USER_ID1",
-            "name_normalized": "ctf1",
-            "is_shared": false,
-            "is_org_shared": false,
-            "is_member": true,
-            "is_private": false,
-            "is_mpim": false,
-            "members": [
-                "UNITTEST_USER_ID1"
-            ],
-            "topic": {
-                "value": "",
-                "creator": "",
-                "last_set": 0
-            },
-            "purpose": {
-                "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"ctf1\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
-                "creator": "UNITTEST_USER_ID1",
-                "last_set": 1532537813
-            },
-            "previous_names": [],
-            "num_members": 2
-        },
-        {
-            "id": "UNITTEST_CHANNEL_ID2",
-            "name": "ctf2",
-            "is_channel": true,
-            "created": 1532537813,
-            "is_archived": false,
-            "is_general": false,
-            "unlinked": 0,
-            "creator": "UNITTEST_USER_ID1",
-            "name_normalized": "ctf2",
-            "is_shared": false,
-            "is_org_shared": false,
-            "is_member": true,
-            "is_private": false,
-            "is_mpim": false,
-            "members": [
-                "UNITTEST_USER_ID1"
-            ],
-            "topic": {
-                "value": "",
-                "creator": "",
-                "last_set": 0
-            },
-            "purpose": {
-                "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"createfix\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
-                "creator": "UNITTEST_USER_ID1",
-                "last_set": 1532537813
-            },
-            "previous_names": [],
-            "num_members": 2
-        }
-    ]
+  "ok": true,
+  "channels": [
+    {
+      "id": "UNITTEST_CHANNEL_ID1",
+      "name": "ctf1",
+      "is_channel": true,
+      "created": 1532537813,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "creator": "UNITTEST_USER_ID1",
+      "name_normalized": "ctf1",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_member": true,
+      "is_private": false,
+      "is_mpim": false,
+      "members": ["UNITTEST_USER_ID1"],
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"ctf1\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
+        "creator": "UNITTEST_USER_ID1",
+        "last_set": 1532537813
+      },
+      "previous_names": [],
+      "num_members": 2
+    },
+    {
+      "id": "UNITTEST_CHANNEL_ID2",
+      "name": "ctf2",
+      "is_channel": true,
+      "created": 1532537813,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "creator": "UNITTEST_USER_ID1",
+      "name_normalized": "ctf2",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_member": true,
+      "is_private": false,
+      "is_mpim": false,
+      "members": ["UNITTEST_USER_ID1"],
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "{\"ota_bot\": \"OTABOT\", \"name\": \"createfix\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"createfix\"}",
+        "creator": "UNITTEST_USER_ID1",
+        "last_set": 1532537813
+      },
+      "previous_names": [],
+      "num_members": 2
+    },
+    {
+      "id": "UNITTEST_CHANNEL_ID3",
+      "name": "finished_ctf",
+      "is_channel": true,
+      "created": 1532537813,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "creator": "UNITTEST_USER_ID1",
+      "name_normalized": "finished_ctf",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_member": true,
+      "is_private": false,
+      "is_mpim": false,
+      "members": ["UNITTEST_USER_ID1"],
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "{\"finished\":true,\"ota_bot\": \"OTABOT\", \"name\": \"finished_ctf\", \"type\": \"CTF\", \"cred_user\": \"\", \"cred_pw\": \"\", \"long_name\": \"finished_ctf\"}",
+        "creator": "UNITTEST_USER_ID1",
+        "last_set": 1532537813
+      },
+      "previous_names": [],
+      "num_members": 2
+    }
+  ]
 }


### PR DESCRIPTION
If there are a few ctfs happening, it can be hard to see which ones are running and which ones are done. This changes the status command to group them together under different headings:

<img width="740" alt="image" src="https://user-images.githubusercontent.com/1418260/85239860-200d3380-b479-11ea-983a-55a7041efb74.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentoallctf/ota-challenge-bot/228)
<!-- Reviewable:end -->
