### PR TITLE
Pull in changes from our friends on Samurai

### DIFF
--- a/config/config.json.template
+++ b/config/config.json.template
@@ -7,5 +7,6 @@
   "wolfram_app_id" : "",
   "archive_ctf_reminder_offset" : "168",
   "delete_watch_keywords" : "",
-  "intro_message" : ""
+  "intro_message" : "",
+  "maintenance_mode": false
 }

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -6,6 +6,7 @@
   "auto_invite" : [],
   "wolfram_app_id" : "",
   "archive_ctf_reminder_offset" : "168",
+  "archive_everything": true,
   "delete_watch_keywords" : "",
   "intro_message" : "",
   "private_ctfs": false

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -8,5 +8,6 @@
   "archive_ctf_reminder_offset" : "168",
   "delete_watch_keywords" : "",
   "intro_message" : "",
+  "private_ctfs": false
   "maintenance_mode": false
 }

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -9,6 +9,7 @@
   "archive_everything": true,
   "delete_watch_keywords" : "",
   "intro_message" : "",
-  "private_ctfs": false
+  "private_ctfs": false,
+  "allow_signup": false,
   "maintenance_mode": false
 }

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -7,6 +7,25 @@ from handlers.base_handler import BaseHandler
 from util.util import (get_display_name_from_user, parse_user_id,
                        resolve_user_by_user_id)
 
+class MakeCTFCommand():
+    """
+        Update the channel purpose to be that of a CTF.
+    """
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        if user_is_admin:
+            purpose = {}
+            purpose["ota_bot"] = "OTABOT"
+            purpose["name"] = args[0]
+            purpose["type"] = "CTF"
+            purpose["cred_user"] = ""
+            purpose["cred_pw"] = ""
+            purpose["long_name"] = args[0]
+            purpose["finished"] = False
+            purpose["finished_on"] = ""
+            slack_wrapper.set_purpose(channel_id, purpose)
+
+
 class PopulateCommand():
     """
         Only callable from a challenge channel.
@@ -179,7 +198,8 @@ class AdminHandler(BaseHandler):
             "populate": CommandDesc(PopulateCommand, "Invite all non-present members of the CTF challenge into the challenge channel", None, None, True),
             "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True),
             "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True),
-            "debug": CommandDesc(StartDebuggerCommand, "Break into a debugger shell", None, None, True)
+            "debug": CommandDesc(StartDebuggerCommand, "Break into a debugger shell", None, None, True),
+            "makectf": CommandDesc(MakeCTFCommand, "Turn the current channel into a CTF channel by setting the purpose. Requires reload to take effect", ["ctf_name"], None, True)
         }
 
         self.aliases = {

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -69,6 +69,22 @@ class StartDebuggerCommand():
             else:
                 InvalidCommand("Must be in maintenance mode to open a shell")
 
+
+class JoinChannelCommand():
+    """
+        Join the named channel.
+    """
+
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        if user_is_admin:
+            channel = slack_wrapper.get_channel_by_name(args[0])
+            if channel:
+                slack_wrapper.invite_user(user_id, channel['id'])
+            else:
+                slack_wrapper.post_message(user_id, "No such channel")
+
+
 class ToggleMaintenanceModeCommand(Command):
     """Update maintenance mode configuration."""
 
@@ -199,6 +215,7 @@ class AdminHandler(BaseHandler):
             "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True),
             "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True),
             "debug": CommandDesc(StartDebuggerCommand, "Break into a debugger shell", None, None, True),
+            "join": CommandDesc(JoinChannelCommand, "Join a channel", ["channel_name"], None, True),
             "makectf": CommandDesc(MakeCTFCommand, "Turn the current channel into a CTF channel by setting the purpose. Requires reload to take effect", ["ctf_name"], None, True)
         }
 

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -35,6 +35,7 @@ class PopulateCommand():
             else:
                 slack_wrapper.post_message(user_id, f"!populate: Failed to retrieve channel information")
 
+
 class StartDebuggerCommand():
     """
         Break into pdb. Better have a tty open!
@@ -168,22 +169,6 @@ class AsCommand(Command):
 class AdminHandler(BaseHandler):
     """
     Handles configuration options for administrators.
-
-    Commands :
-    # Show administrator users
-    !admin show_admins
-
-    # Add a user to the administrator group
-    !admin add_admin user_id
-
-    # Remove a user from the administrator group
-    !admin remove_admin user_id
-
-    # Put the bot into maintenance mode
-    !maintenance
-
-    # Break into a pdb shell
-    !debug
     """
 
     def __init__(self):

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -1,3 +1,4 @@
+import json
 from bottypes.command import Command
 from bottypes.command_descriptor import CommandDesc
 from bottypes.invalid_command import InvalidCommand
@@ -5,6 +6,20 @@ from handlers import handler_factory
 from handlers.base_handler import BaseHandler
 from util.util import (get_display_name_from_user, parse_user_id,
                        resolve_user_by_user_id)
+
+class StartDebuggerCommand():
+    """
+        Break into pdb. Better have a tty open!
+        Must be in maintenance mode to use.
+    """
+
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        if user_is_admin:
+            if handler_factory.botserver.get_config_option("maintenance_mode"):
+                import pdb; pdb.set_trace()
+            else:
+                InvalidCommand("Must be in maintenance mode to open a shell")
 
 class ToggleMaintenanceModeCommand(Command):
     """Update maintenance mode configuration."""
@@ -138,6 +153,9 @@ class AdminHandler(BaseHandler):
 
     # Put the bot into maintenance mode
     !maintenance
+
+    # Break into a pdb shell
+    !debug
     """
 
     def __init__(self):
@@ -146,7 +164,8 @@ class AdminHandler(BaseHandler):
             "add_admin": CommandDesc(AddAdminCommand, "Add a user to the admin user group", ["user_id"], None, True),
             "remove_admin": CommandDesc(RemoveAdminCommand, "Remove a user from the admin user group", ["user_id"], None, True),
             "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True),
-            "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True)
+            "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True),
+            "debug": CommandDesc(StartDebuggerCommand, "Break into a debugger shell", None, None, True)
         }
 
 

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -7,6 +7,34 @@ from handlers.base_handler import BaseHandler
 from util.util import (get_display_name_from_user, parse_user_id,
                        resolve_user_by_user_id)
 
+class PopulateCommand():
+    """
+        Only callable from a challenge channel.
+        Invite everyone in the CTF channel into the current channel.
+    """
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        if user_is_admin:
+            response = slack_wrapper.get_channel_info(channel_id)
+            if response['ok']:
+                try:
+                    purpose = json.loads(response['channel']['purpose']['value'])
+                    if purpose['ctf_id'] and purpose["type"] == 'CHALLENGE':
+                        members = slack_wrapper.get_channel_members(purpose['ctf_id'])
+                        present = slack_wrapper.get_channel_members(channel_id)
+                        invites = list(set(members)-set(present))
+                        if len(invites) > 0:
+                            slack_wrapper.post_message(user_id, f"Inviting {len(invites)} users", timestamp)
+                            slack_wrapper.invite_user(invites, channel_id)
+                        else:
+                            slack_wrapper.post_message(user_id, "Everyone's already here", timestamp)
+                    else:
+                        slack_wrapper.post_message(user_id, 'Invalid challenge channel - check the purpose is set correctly')
+                except:
+                    slack_wrapper.post_message(user_id, f"!populate: Failed in parsing the channel purpose")
+            else:
+                slack_wrapper.post_message(user_id, f"!populate: Failed to retrieve channel information")
+
 class StartDebuggerCommand():
     """
         Break into pdb. Better have a tty open!
@@ -163,10 +191,15 @@ class AdminHandler(BaseHandler):
             "show_admins": CommandDesc(ShowAdminsCommand, "Show a list of current admin users", None, None, True),
             "add_admin": CommandDesc(AddAdminCommand, "Add a user to the admin user group", ["user_id"], None, True),
             "remove_admin": CommandDesc(RemoveAdminCommand, "Remove a user from the admin user group", ["user_id"], None, True),
+            "populate": CommandDesc(PopulateCommand, "Invite all non-present members of the CTF challenge into the challenge channel", None, None, True),
             "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True),
             "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True),
             "debug": CommandDesc(StartDebuggerCommand, "Break into a debugger shell", None, None, True)
         }
 
+        self.aliases = {
+            "gather": "populate",
+            "summon": "populate"
+        }
 
 handler_factory.register("admin", AdminHandler())

--- a/handlers/admin_handler.py
+++ b/handlers/admin_handler.py
@@ -6,6 +6,18 @@ from handlers.base_handler import BaseHandler
 from util.util import (get_display_name_from_user, parse_user_id,
                        resolve_user_by_user_id)
 
+class ToggleMaintenanceModeCommand(Command):
+    """Update maintenance mode configuration."""
+
+    @classmethod
+    def execute(cls, slack_wrapper, args, timestamp, channel_id, user_id, user_is_admin):
+        """Execute the ToggleMaintenanceModeCommand command."""
+        mode = not bool(handler_factory.botserver.get_config_option("maintenance_mode"))
+        state = "enabled" if mode else "disabled"
+        handler_factory.botserver.set_config_option("maintenance_mode", mode)
+        text = "Maintenance mode " + state
+        slack_wrapper.post_message(channel_id, text)
+
 
 class ShowAdminsCommand(Command):
     """Shows list of users in the admin user group."""
@@ -123,6 +135,9 @@ class AdminHandler(BaseHandler):
 
     # Remove a user from the administrator group
     !admin remove_admin user_id
+
+    # Put the bot into maintenance mode
+    !maintenance
     """
 
     def __init__(self):
@@ -130,7 +145,8 @@ class AdminHandler(BaseHandler):
             "show_admins": CommandDesc(ShowAdminsCommand, "Show a list of current admin users", None, None, True),
             "add_admin": CommandDesc(AddAdminCommand, "Add a user to the admin user group", ["user_id"], None, True),
             "remove_admin": CommandDesc(RemoveAdminCommand, "Remove a user from the admin user group", ["user_id"], None, True),
-            "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True)
+            "as": CommandDesc(AsCommand, "Execute a command as another user", ["@user", "command"], None, True),
+            "maintenance": CommandDesc(ToggleMaintenanceModeCommand, "Toggle maintenance mode", None, None, True)
         }
 
 

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -87,8 +87,12 @@ class BaseHandler(ABC):
         return msg
 
     def process(self, slack_wrapper, command, args, timestamp, channel, user, user_is_admin):
-        if handler_factory.botserver.get_config_option("maintenance_mode") and not user_is_admin:
-            raise InvalidCommand("Down for maintenance, back soon.")
+        if handler_factory.botserver.get_config_option("maintenance_mode"):
+            if user_is_admin:
+                slack_wrapper.post_message(channel, "Warning! Maintenance mode is enabled!", timestamp)
+            else:
+                slack_wrapper.post_message(channel, "Down for maintenance, back soon.", timestamp)
+                return
 
         """Check if enough arguments were passed for this command."""
         if command in self.aliases:

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from bottypes.invalid_command import InvalidCommand
+from handlers import handler_factory
 
 
 class BaseHandler(ABC):
@@ -86,6 +87,9 @@ class BaseHandler(ABC):
         return msg
 
     def process(self, slack_wrapper, command, args, timestamp, channel, user, user_is_admin):
+        if handler_factory.botserver.get_config_option("maintenance_mode") and not user_is_admin:
+            raise InvalidCommand("Down for maintenance, back soon.")
+
         """Check if enough arguments were passed for this command."""
         if command in self.aliases:
             self.process(slack_wrapper, self.aliases[command], args, timestamp, channel, user, user_is_admin)
@@ -98,6 +102,9 @@ class BaseHandler(ABC):
                 cmd_descriptor.command.execute(slack_wrapper, args, timestamp, channel, user, user_is_admin)
 
     def process_reaction(self, slack_wrapper, reaction, channel, timestamp, user, user_is_admin):
+        if handler_factory.botserver.get_config_option("maintenance_mode") and not user_is_admin:
+            raise InvalidCommand("Down for maintenance, back soon.")
+
         reaction_descriptor = self.reactions[reaction]
 
         if reaction_descriptor:

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -965,7 +965,7 @@ class ChallengeHandler(BaseHandler):
     def __init__(self):
         self.commands = {
             "addctf": CommandDesc(AddCTFCommand, "Adds a new ctf", ["ctf_name", "long_name"], None),
-            "addchallenge": CommandDesc(AddChallengeCommand, "Adds a new challenge for current ctf", ["challenge_name", "challenge_category"], None),
+            "addchallenge": CommandDesc(AddChallengeCommand, "Adds a new challenge for current ctf", ["challenge_name"], ["challenge_category"]),
             "workon": CommandDesc(WorkonCommand, "Show that you're working on a challenge", None, ["challenge_name"]),
             "status": CommandDesc(StatusCommand, "Show the status for all ongoing ctf's", None, ["category"]),
             "solve": CommandDesc(SolveCommand, "Mark a challenge as solved", None, ["challenge_name", "support_member"]),

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -331,7 +331,9 @@ class AddChallengeCommand(Command):
         if handler_factory.botserver.get_config_option("auto_invite") == True:
             # Invite everyone in the ctf channel
             members = slack_wrapper.get_channel_members(ctf.channel_id)
-            slack_wrapper.invite_user(members, challenge_channel_id)
+            present = slack_wrapper.get_channel_members(challenge_channel_id)
+            invites = list(set(members)-set(present))
+            slack_wrapper.invite_user(invites, challenge_channel_id)
         else:
             # Invite everyone in the auto-invite list
             for invite_user_id in handler_factory.botserver.get_config_option("auto_invite"):

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -115,7 +115,8 @@ class AddCTFCommand(Command):
             raise InvalidCommand("Add CTF failed: Invalid characters for CTF name found.")
 
         # Create the channel
-        response = slack_wrapper.create_channel(name)
+        private_ctf = handler_factory.botserver.get_config_option("private_ctfs")
+        response = slack_wrapper.create_channel(name, is_private=private_ctf)
 
         # Validate that the channel was successfully created.
         if not response['ok']:
@@ -290,7 +291,7 @@ class AddChallengeCommand(Command):
             raise InvalidCommand("\"{}\" channel creation failed:\nError : {}".format(channel_name, response['error']))
 
         # Add purpose tag for persistence
-        challenge_channel_id = response['group']['id']
+        challenge_channel_id = response['channel']['id']
         purpose = dict(ChallengeHandler.CHALL_PURPOSE)
         purpose['name'] = name
         purpose['ctf_id'] = ctf.channel_id

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -1013,8 +1013,8 @@ class ChallengeHandler(BaseHandler):
         Reload the ctf and challenge information from slack.
         """
         database = {}
-        privchans = slack_wrapper.get_private_channels()["groups"]
-        pubchans = slack_wrapper.get_public_channels()["channels"]
+        privchans = slack_wrapper.get_private_channels()
+        pubchans = slack_wrapper.get_public_channels()
 
         # Find active CTF channels
         for channel in [*privchans, *pubchans]:
@@ -1034,8 +1034,7 @@ class ChallengeHandler(BaseHandler):
                 pass
 
         # Find active challenge channels
-        response = slack_wrapper.get_private_channels()
-        for channel in response['groups']:
+        for channel in privchans:
             try:
                 purpose = load_json(channel['purpose']['value'])
 
@@ -1050,7 +1049,8 @@ class ChallengeHandler(BaseHandler):
                         challenge.mark_as_solved(solvers, purpose.get("solve_date"))
 
                     if ctf:
-                        for member_id in channel['members']:
+                        members = slack_wrapper.get_channel_members(channel['id'])
+                        for member_id in members:
                             if member_id != slack_wrapper.user_id:
                                 challenge.add_player(Player(member_id))
 

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -794,7 +794,7 @@ class ArchiveCTFCommand(Command):
         message = "Archived the following channels :\n"
         for challenge in challenges:
             message += "- #{}-{}\n".format(ctf.name, challenge.name)
-            slack_wrapper.archive_private_channel(challenge.channel_id)
+            slack_wrapper.archive_channel(challenge.channel_id)
             remove_challenge_by_channel_id(ChallengeHandler.DB, challenge.channel_id, ctf.channel_id)
 
         # Remove possible configured reminders for this ctf
@@ -808,7 +808,7 @@ class ArchiveCTFCommand(Command):
         slack_wrapper.post_message(channel_id, message)
 
         # Archive the main CTF channel also to cleanup
-        slack_wrapper.archive_public_channel(channel_id)
+        slack_wrapper.archive_channel(channel_id)
 
 
 class EndCTFCommand(Command):
@@ -989,7 +989,8 @@ class ChallengeHandler(BaseHandler):
         self.aliases = {
             "finishctf": "endctf",
             "addchall": "addchallenge",
-            "add": "addchallenge"
+            "add": "addchallenge",
+            "archive": "archivectf"
         }
 
     @staticmethod

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -547,12 +547,11 @@ class StatusCommand(Command):
                         if player_id in members:
                             players.append(members[player_id])
 
-                    response += "[{} active] *{}* {}: {} {}\n".  format(
+                    response += "[{} active] *{}* {}: {}\n".  format(
                         len(players),
                         challenge.name,
                         "[{}]".format(", ".join(challenge.tags)) if len(challenge.tags) > 0 else "",
-                        "({})".format(challenge.category) if challenge.category else "",
-                        transliterate(", ".join(players)))
+                        "({})".format(challenge.category) if challenge.category else "")
         response = response.strip()
 
         if response == "":  # Response is empty

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -806,8 +806,16 @@ class ArchiveCTFCommand(Command):
         # Show confirmation message
         slack_wrapper.post_message(channel_id, message)
 
-        # Archive the main CTF channel also to cleanup
-        slack_wrapper.archive_channel(channel_id)
+        # If configured to do so, archive the main CTF channel also to cleanup
+        if handler_factory.botserver.get_config_option('archive_everything'):
+            slack_wrapper.archive_channel(channel_id)
+        else:
+            # Otherwise, just set the ctf to finished
+            if not ctf.finished:
+                ctf.finished = True
+                ctf.finished_on = int(time.time())
+
+
 
 
 class EndCTFCommand(Command):

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -949,7 +949,8 @@ class ChallengeHandler(BaseHandler):
         "cred_user": "",
         "cred_pw": "",
         "long_name": "",
-        "finished": False
+        "finished": False,
+        "finished_on": 0
     }
 
     CHALL_PURPOSE = {

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -302,9 +302,8 @@ class AddChallengeCommand(Command):
 
         if handler_factory.botserver.get_config_option("auto_invite") == True:
             # Invite everyone in the ctf channel
-            members = slack_wrapper.get_channel_members(ctf.channel_id, is_private=True)
-            for member in members:
-                slack_wrapper.invite_user(member, challenge_channel_id, is_private=True)
+            members = slack_wrapper.get_channel_members(ctf.channel_id)
+            slack_wrapper.invite_user(members, challenge_channel_id)
         else:
             # Invite everyone in the auto-invite list
             for invite_user_id in handler_factory.botserver.get_config_option("auto_invite"):

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -989,6 +989,7 @@ class ChallengeHandler(BaseHandler):
         self.aliases = {
             "finishctf": "endctf",
             "addchall": "addchallenge",
+            "add": "addchallenge"
         }
 
     @staticmethod

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -299,9 +299,15 @@ class AddChallengeCommand(Command):
         purpose = json.dumps(purpose)
         slack_wrapper.set_purpose(challenge_channel_id, purpose, is_private=True)
 
-        # Invite everyone in the auto-invite list
-        for invite_user_id in handler_factory.botserver.get_config_option("auto_invite"):
-            slack_wrapper.invite_user(invite_user_id, challenge_channel_id, is_private=True)
+        if handler_factory.botserver.get_config_option("auto_invite") == True:
+            # Invite everyone in the ctf channel
+            members = slack_wrapper.get_channel_members(ctf.channel_id, is_private=True)
+            for member in members:
+                slack_wrapper.invite_user(member, challenge_channel_id, is_private=True)
+        else:
+            # Invite everyone in the auto-invite list
+            for invite_user_id in handler_factory.botserver.get_config_option("auto_invite"):
+                slack_wrapper.invite_user(invite_user_id, challenge_channel_id, is_private=True)
 
         # New Challenge
         challenge = Challenge(ctf.channel_id, challenge_channel_id, name, category)

--- a/server/botserver.py
+++ b/server/botserver.py
@@ -68,7 +68,7 @@ class BotServer(threading.Thread):
                 log.info("Updated configuration: %s => %s", option, value)
 
                 with open("./config/config.json", "w") as f:
-                    json.dump(self.config, f)
+                    json.dump(self.config, f, indent=4)
             else:
                 raise InvalidConsoleCommand("The specified configuration option doesn't exist: {}".format(option))
         finally:

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -98,7 +98,7 @@ class SlackWrapper:
         if not next_cursor:
             return members
         else:
-            return members + self.get_members(channel_id, next_cursor)
+            return members + self.get_channel_members(channel_id, next_cursor)
 
     def update_channel_purpose_name(self, channel_id, new_name, is_private=False):
         """

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -148,6 +148,16 @@ class SlackWrapper:
         else:
             return channels + self.get_channels(types, next_cursor)
 
+    def get_all_channels(self):
+        """Fetch all channels."""
+        return self.get_channels(["public_channel", "private_channel"])
+
+    def get_channel_by_name(self, name):
+        """Fetch a channel with a given name."""
+        channels = self.get_all_channels()
+        for channel in channels:
+            if channel['name'] == name:
+                return channel
 
     def get_public_channels(self):
         """Fetch all public channels."""

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -92,7 +92,9 @@ class SlackWrapper:
     def get_channel_members(self, channel_id, is_private=False):
         """ Return list of member ids in a given channel ID. """
 
-        return self.get_channel_info(channel_id, is_private)['channel']['members']
+        key = 'group' if is_private else 'channel'
+
+        return self.get_channel_info(channel_id, is_private)[key]['members']
 
     def update_channel_purpose_name(self, channel_id, new_name, is_private=False):
         """

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -169,6 +169,10 @@ class SlackWrapper:
         """Fetch all private channels in which the user participates."""
         return self.get_channels("private_channel")
 
+    def archive_channel(self, channel_id):
+        """Archive a channel"""
+        return self.client.api_call("conversations.archive", channel=channel_id)
+
     def archive_private_channel(self, channel_id):
         """Archive a private channel"""
         return self.client.api_call("groups.archive", channel=channel_id)

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -45,7 +45,7 @@ class SlackWrapper:
         Set the purpose of a given channel.
         """
 
-        api_call = "groups.setPurpose" if is_private else "channels.setPurpose"
+        api_call = "conversations.setPurpose"
         return self.client.api_call(api_call, purpose=purpose, channel=channel)
 
     def set_topic(self, channel, topic, is_private=False):

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -136,13 +136,25 @@ class SlackWrapper:
         """Update a message, identified by the specified timestamp with a new text."""
         self.client.api_call("chat.update", channel=channel_id, text=text, ts=msg_timestamp, as_user=True, parse=parse)
 
+    def get_channels(self, types, next_cursor=None):
+        """Recursively fetch channels, until there are no more to be fetched."""
+        types = [types] if type(types) != list else types
+        response = self.client.api_call("conversations.list", types=types, cursor=next_cursor)
+        channels = response['channels']
+        next_cursor = response['response_metadata']['next_cursor']
+        if not next_cursor:
+            return channels
+        else:
+            return channels + self.get_channels(types, next_cursor)
+
+
     def get_public_channels(self):
         """Fetch all public channels."""
-        return self.client.api_call("channels.list")
+        return self.get_channels("public_channel")
 
     def get_private_channels(self):
         """Fetch all private channels in which the user participates."""
-        return self.client.api_call("groups.list")
+        return self.get_channels("private_channel")
 
     def archive_private_channel(self, channel_id):
         """Archive a private channel"""

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -32,13 +32,14 @@ class SlackWrapper:
         """Read from the real-time messaging API."""
         return self.client.rtm_read()
 
-    def invite_user(self, user, channel, is_private=False):
+    def invite_user(self, users, channel, is_private=False):
         """
-        Invite a user to a given channel.
+        Invite the given user(s) to the given channel.
         """
 
-        api_call = "groups.invite" if is_private else "channels.invite"
-        return self.client.api_call(api_call, channel=channel, user=user)
+        users = [users] if not type(users) == list else users
+        api_call = "conversations.invite"
+        return self.client.api_call(api_call, channel=channel, users=users)
 
     def set_purpose(self, channel, purpose, is_private=False):
         """
@@ -70,8 +71,8 @@ class SlackWrapper:
         """
         Create a channel with a given name.
         """
-        api_call = "groups.create" if is_private else "channels.create"
-        return self.client.api_call(api_call, name=name, validate=False)
+        api_call = "conversations.create"
+        return self.client.api_call(api_call, name=name, is_private=is_private)
 
     def rename_channel(self, channel_id, new_name, is_private=False):
         """


### PR DESCRIPTION
New features:
- Ability to create private CTFs (be194564)
    New config option "private_ctfs". When true, new ctfs will be created as
    private channels instead of public channels.
- Ability to auto-invite all CTF channel members to new challenges(1a087b15)
    Override 'auto_invite' config option so as to automatically invite everyone 
    in the channel to newly created challenges by setting its value to 'True'. 
    Any value other than "True" for the key will cause it to function as before, 
    which is to auto invite only the listed members.
 - Ability to archive only challenges (fff0bdab2)
    Set `archive_everything` to false in the config file and the
    `!archivectf` will archive the challenge channels but not the CTF
    channel.
    NOTE: The CTF channel will be marked as finished if it hasn't already been.
New commands:
- `!signup` (566b39b62)
    !signup <ctf_name> will automatically add the caller to an existing CTF
    of the same name, along with any challenge channels that currently
    exist.
    Enabling this command requires creating an "allow_signup" key in the
    config and setting it to a truthy value.
    CTFs cannot be signed up for if they have been marked finished.
- `!populate` (`!gather`, `!summon`) (8a7d77d0d)
    Call from either a CTF or a challenge channel.
    Take a list of user names and invite each into the CTF channel where the
    command has been executed. If the call has been made from a challenge
    channel, invite the users into the parent CTF channel for that challenge,
    and then invite the users into the challenge channel as well.
    In the event that there are no users to be invited, for example because
    the users in the list are already present in the channel(s), no API call
    to Slack will occur.
    NOTE: This started as an admin-only feature but is now generally available.
    NOTE: Review and revert `0251853ed` to make this command admin only again.
New admin commands:
- `!join` (c0f2db9a)
    Allow bot administrators to join any channel by name, even if the channel
    is private. Useful for debugging.
    NOTE: Bot must be present in the room for this to work.
    NOTE: Does not allow joining to private messages, even when the bot is present.
- `!makectf` (cec0d3e95)
    Convenience method that sets the channel from which the command is
    invoked to be like that of a freshly created CTF channel. Useful when
    debugging.
- `!maintenance` (01103f758)
    Put the bot into maintenance mode.  In maintenance mode, any non-admin
    users who attempt to use the bot will get a short message indicating that the
    bot is down for service.  
    NOTE: Admin users will continue to be able to issue commands like normal.
- `!debug` (3f7730f53)
    After putting the bot into maintenance mode with !maintenance, a bot admin
    may call !debug to break into pdb. Be certain to have a tty on the running
    process, else you will probably have to reboot.
New functions
- `get_channel_by_name()` (4a36d1d8e)
    Search all available channels for a channel with the given name and
    return it.
API Updates
- Update AddCTFCommand to handle results of call to conversations API. (b1e94564e)
- Switch `set_purpose` from events to conversations API. (a6048e737)
- Implement the conversations API for listing channels. (4a36d1d8e)
- Update get_channel_members() to use new slack API. (3c8d7078)
- Update `!archivectf` to use new slack API. (c2413421)
Miscellaneous: 
- Make category optional when adding challenge (5fc646853)
- Stop `set_config_option` mangling file indentation (f2394ed1a)
- Remove player list from status to cut down on noise (c6aebbba)
- Alias `!archive` and `!archivectf` (c24134213)
- Make `!add` an alias of `!addchallenge` (3ff51e79)