### PR TITLE
update to use new slack api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ config/config_solvetracker.json
 .venv
 intro_msg
 .vscode
+.idea/
+*.iml

--- a/handlers/challenge_handler.py
+++ b/handlers/challenge_handler.py
@@ -237,13 +237,13 @@ class RenameChallengeCommand(Command):
             raise InvalidCommand("Rename challenge failed: Challenge '{}' not found.".format(old_name))
 
         log.debug("Renaming channel %s to %s", channel_id, new_name)
-        response = slack_wrapper.rename_channel(challenge.channel_id, new_channel_name, is_private=True)
+        response = slack_wrapper.rename_channel(challenge.channel_id, new_channel_name)
 
         if not response['ok']:
             raise InvalidCommand("\"{}\" channel rename failed:\nError: {}".format(old_channel_name, response['error']))
 
         # Update channel purpose
-        slack_wrapper.update_channel_purpose_name(challenge.channel_id, new_name, is_private=True)
+        slack_wrapper.update_channel_purpose_name(challenge.channel_id, new_name)
 
         # Update database
         update_challenge_name(ChallengeHandler.DB,
@@ -352,7 +352,7 @@ class AddChallengeCommand(Command):
         purpose['category'] = category
 
         purpose = json.dumps(purpose)
-        slack_wrapper.set_purpose(challenge_channel_id, purpose, is_private=True)
+        slack_wrapper.set_purpose(challenge_channel_id, purpose)
 
         if handler_factory.botserver.get_config_option("auto_invite") == True:
             # Invite everyone in the ctf channel
@@ -363,7 +363,7 @@ class AddChallengeCommand(Command):
         else:
             # Invite everyone in the auto-invite list
             for invite_user_id in handler_factory.botserver.get_config_option("auto_invite"):
-                slack_wrapper.invite_user(invite_user_id, challenge_channel_id, is_private=True)
+                slack_wrapper.invite_user(invite_user_id, challenge_channel_id)
 
         # New Challenge
         challenge = Challenge(ctf.channel_id, challenge_channel_id, name, category)
@@ -523,12 +523,7 @@ class StatusCommand(Command):
         """Build verbose status list."""
         member_list = slack_wrapper.get_members()
 
-        # Bail out, if we couldn't read member list
-        if not "members" in member_list:
-            raise InvalidCommand("Status failed. Could not refresh member list...")
-
-        members = {m["id"]: get_display_name_from_user(m)
-                   for m in member_list['members']}
+        members = {m["id"]: get_display_name_from_user(m) for m in member_list}
 
         response = ""
         for ctf in ctf_list:
@@ -662,7 +657,7 @@ class WorkonCommand(Command):
             raise InvalidCommand("This challenge is already solved.")
 
         # Invite user to challenge channel
-        slack_wrapper.invite_user(user_id, challenge.channel_id, is_private=True)
+        slack_wrapper.invite_user(user_id, challenge.channel_id)
 
         # Update database
         ctfs = pickle.load(open(ChallengeHandler.DB, "rb"))
@@ -746,7 +741,7 @@ class SolveCommand(Command):
                         purpose['category'] = chal.category
 
                         purpose = json.dumps(purpose)
-                        slack_wrapper.set_purpose(challenge.channel_id, purpose, is_private=True)
+                        slack_wrapper.set_purpose(challenge.channel_id, purpose)
 
                         # Announce the CTF channel
                         help_members = ""
@@ -802,7 +797,7 @@ class UnsolveCommand(Command):
                         purpose['category'] = challenge.category
 
                         purpose = json.dumps(purpose)
-                        slack_wrapper.set_purpose(challenge.channel_id, purpose, is_private=True)
+                        slack_wrapper.set_purpose(challenge.channel_id, purpose)
 
                         # Announce the CTF channel
                         message = "@here *{}* : {} has reset the solve on the \"{}\" challenge.".format(

--- a/handlers/handler_factory.py
+++ b/handlers/handler_factory.py
@@ -122,7 +122,7 @@ def process_command(slack_wrapper, message, args, timestamp, channel_id, user_id
             slack_wrapper.post_message(target_id, usage_msg)
 
     except InvalidCommand as e:
-        slack_wrapper.post_message(channel_id, e, timestamp)
+        slack_wrapper.post_message(channel_id, str(e), timestamp)
 
     except Exception:
         log.exception("An error has occured while processing a command")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,12 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 more-itertools==4.3.0
 pylint==2.1.1
+python-dateutil==2.8.0
 requests==2.20.0
 six==1.11.0
+slack-sdk==3.2.0
 slackclient==1.3.0
+soupsieve==2.1
 Unidecode==1.0.22
 urllib3==1.24.2
 websocket-client==0.53.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
+import unittest
 from unittest import TestCase
 
 from slack_sdk.socket_mode.request import SocketModeRequest
 
 from tests.slackwrapper_mock import SlackWrapperMock
-import unittest
 from util.loghandler import log, logging
 from server.botserver import BotServer
 from bottypes.invalid_command import InvalidCommand

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 from unittest import TestCase
+
+from slack_sdk.socket_mode.request import SocketModeRequest
+
 from tests.slackwrapper_mock import SlackWrapperMock
 import unittest
 from util.loghandler import log, logging
@@ -39,16 +42,22 @@ class BotBaseTest(TestCase):
 
     def exec_command(self, msg, exec_user="normal_user", channel="UNITTESTCHANNELID"):
         """Simulate execution of the specified message as the specified user in the test environment."""
-        testmsg = [{'type': 'message', 'user': exec_user, 'text': msg, 'client_msg_id': '738e4beb-d50e-42a4-a60e-3fafd4bd71da',
-                    'team': 'UNITTESTTEAMID', 'channel': channel, 'event_ts': '1549715670.002000', 'ts': '1549715670.002000'}]
-        self.botserver.handle_message(testmsg)
+        testmsg = {'type': 'event_callback',
+                   'event': {'type': 'message', 'user': exec_user, 'text': msg,
+                             'client_msg_id': '738e4beb-d50e-42a4-a60e-3fafd4bd71da',
+                             'team': 'UNITTESTTEAMID', 'channel': channel,
+                             'event_ts': '1549715670.002000', 'ts': '1549715670.002000'}}
+        self.botserver.handle_message(SocketModeRequest(type='events_api', envelope_id='', payload=testmsg))
 
     def exec_reaction(self, reaction, exec_user="normal_user"):
         """Simulate execution of the specified reaction as the specified user in the test environment."""
-        testmsg = [{'type': 'reaction_added', 'user': exec_user, 'item': {'type': 'message', 'channel': 'UNITTESTCHANNELID', 'ts': '1549117537.000500'},
-                    'reaction': reaction, 'item_user': 'UNITTESTUSERID', 'event_ts': '1549715822.000800', 'ts': '1549715822.000800'}]
+        testmsg = {'type': 'event_callback',
+                   'event': {'type': 'reaction_added', 'user': exec_user,
+                             'item': {'type': 'message', 'channel': 'UNITTESTCHANNELID', 'ts': '1549117537.000500'},
+                             'reaction': reaction, 'item_user': 'UNITTESTUSERID',
+                             'event_ts': '1549715822.000800', 'ts': '1549715822.000800'}}
 
-        self.botserver.handle_message(testmsg)
+        self.botserver.handle_message(SocketModeRequest(type='events_api', envelope_id='', payload=testmsg))
 
     def check_for_response_available(self):
         return len(self.botserver.slack_wrapper.message_list) > 0

--- a/server/botserver.py
+++ b/server/botserver.py
@@ -143,9 +143,11 @@ class BotServer(threading.Thread):
         handler_factory.initialize(self.slack_wrapper, self)
 
     def handle_message(self, message: SocketModeRequest):
-        assert(message.payload['type'] == 'event_callback')
+        if message.payload["type"] != "event_callback":
+            log.warning("unexpected payload type %s", message.payload["type"])
+            return
 
-        message_list = [message.payload['event']]
+        message_list = [message.payload["event"]]
 
         reaction, channel, time_stamp, reaction_user = self.parse_slack_reaction(message_list)
 

--- a/server/botserver.py
+++ b/server/botserver.py
@@ -3,6 +3,7 @@ import threading
 import time
 
 import websocket
+from slack_sdk.socket_mode.request import SocketModeRequest
 from slackclient.server import SlackConnectionError
 
 from bottypes.invalid_console_command import InvalidConsoleCommand
@@ -141,14 +142,18 @@ class BotServer(threading.Thread):
         log.info("Initializing handlers...")
         handler_factory.initialize(self.slack_wrapper, self)
 
-    def handle_message(self, message):
-        reaction, channel, time_stamp, reaction_user = self.parse_slack_reaction(message)
+    def handle_message(self, message: SocketModeRequest):
+        assert(message.payload['type'] == 'event_callback')
+
+        message_list = [message.payload['event']]
+
+        reaction, channel, time_stamp, reaction_user = self.parse_slack_reaction(message_list)
 
         if reaction and not self.bot_id == reaction_user:
             log.debug("Received reaction : %s (%s)", reaction, channel)
             handler_factory.process_reaction(self.slack_wrapper, reaction, time_stamp, channel, reaction_user)
 
-        command, channel, time_stamp, user = self.parse_slack_message(message)
+        command, channel, time_stamp, user = self.parse_slack_message(message_list)
 
         if command and not self.bot_id == user:
             log.debug("Received bot command : %s (%s)", command, channel)
@@ -162,7 +167,11 @@ class BotServer(threading.Thread):
         while self.running:
             try:
                 self.load_config()
-                self.slack_wrapper = SlackWrapper(self.get_config_option("api_key"))
+                self.slack_wrapper = SlackWrapper(
+                    self.get_config_option("api_key"),
+                    self.get_config_option("app_key"),
+                    self.handle_message,
+                )
 
                 if self.slack_wrapper.connected:
                     log.info("Connection successful...")
@@ -170,13 +179,7 @@ class BotServer(threading.Thread):
 
                     # Main loop
                     log.info("Bot is running...")
-                    while self.running:
-                        message = self.slack_wrapper.read()
-                        if message:
-                            self.handle_message(message)
-
-                        time.sleep(self.read_websocket_delay)
-
+                    threading.Event().wait()
                 else:
                     log.error("Connection failed. Invalid slack token or bot id?")
                     self.running = False

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -23,7 +23,7 @@ class SlackWrapper:
         """
         SlackWrapper constructor.
         Connect to the real-time messaging API and
-        load the bot"s login data.
+        load the bot's login data.
         """
         self.client = WebClient(slack_token)
 

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -1,202 +1,223 @@
 import json
-import time
+from typing import Any, List, Dict, Union
 
-from slackclient import SlackClient
+from slack_sdk import WebClient
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.web import SlackResponse
+from slack_sdk.socket_mode import SocketModeClient
+
 from util.util import load_json
 
 
 class SlackWrapper:
     """
     Slack API wrapper
+
+    Does not validate responses!
     """
 
-    def __init__(self, api_key):
+    def __init__(self, slack_token, socket_mode_token, handler):
         """
         SlackWrapper constructor.
         Connect to the real-time messaging API and
         load the bot's login data.
         """
-        self.api_key = api_key
-        self.client = SlackClient(self.api_key)
-        self.connected = self.client.rtm_connect(auto_reconnect=True)
-        self.server = None
-        self.username = None
-        self.user_id = None
+        self.client = WebClient(slack_token)
 
-        if self.connected:
-            self.server = self.client.server
-            self.username = self.server.username
-            self.user_id = self.server.login_data.get("self").get("id")
+        identity = self.client.auth_test()
+        identity.validate()
 
-    def read(self):
-        """Read from the real-time messaging API."""
-        return self.client.rtm_read()
+        self.user_id = identity['user_id']
+        self.username = identity['user']
 
-    def invite_user(self, users, channel, is_private=False):
+        self.on_message_handlers = [handler]
+        self.seen_messages = []
+
+        self.socket = SocketModeClient(socket_mode_token)
+        self.socket.connect()
+        self.socket.socket_mode_request_listeners.append(self.handle)
+
+    @property
+    def connected(self):
+        return self.socket.is_connected()
+
+    def handle(self, client: SocketModeClient, message: SocketModeRequest):
+        # send the response immediately so we don't get retransmissions
+        client.send_socket_mode_response(SocketModeResponse(message.envelope_id))
+
+        # slack is super eager to retransmit so here's a free memory leak
+        id = message.payload['event']['client_msg_id']
+        if id in self.seen_messages:
+            return
+
+        self.seen_messages.append(id)
+
+        for handler in self.on_message_handlers:
+            try:
+                handler(message)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                print("error handling message", e)
+
+    def on_message(self, handler):
+        self.on_message_handlers.append(handler)
+
+    def invite_user(self, user: Union[str, Sequence[str]], channel: str) -> Dict:
         """
         Invite the given user(s) to the given channel.
         """
 
-        users = [users] if not type(users) == list else users
-        api_call = "conversations.invite"
-        return self.client.api_call(api_call, channel=channel, users=users)
+        return self.client.conversations_invite(channel=channel, users=user).data
 
-    def set_purpose(self, channel, purpose, is_private=False):
+    def set_purpose(self, channel: str, purpose: str) -> Dict:
         """
         Set the purpose of a given channel.
         """
 
-        api_call = "conversations.setPurpose"
-        return self.client.api_call(api_call, purpose=purpose, channel=channel)
+        return self.client.conversations_setPurpose(channel=channel, purpose=purpose).data
 
-    def set_topic(self, channel, topic, is_private=False):
+    def set_topic(self, channel: str, topic: str) -> Dict:
         """Set the topic of a given channel."""
 
-        api_call = "groups.setTopic" if is_private else "channels.setTopic"
-        return self.client.api_call(api_call, topic=topic, channel=channel)
+        return self.client.conversations_setTopic(channel=channel, topic=topic).data
 
-    def get_members(self):
+    def get_members(self) -> List[Dict]:
         """
-        Return a list of all members.
+        Return a list of all members. Will raise exception if list fails
         """
-        return self.client.api_call("users.list", presence=True)
 
-    def get_member(self, user_id):
+        members = []
+        for page in self.client.users_list():
+            members.extend(page['members'])
+
+        return members
+
+    def get_member(self, user_id: str) -> Dict:
         """
         Return a member for a given user_id.
         """
-        return self.client.api_call("users.info", user=user_id)
 
-    def create_channel(self, name, is_private=False):
+        return self.client.users_info(user=user_id).data
+
+    def create_channel(self, name: str, is_private=False) -> Dict:
         """
         Create a channel with a given name.
         """
-        api_call = "conversations.create"
-        return self.client.api_call(api_call, name=name, is_private=is_private)
 
-    def rename_channel(self, channel_id, new_name, is_private=False):
+        return self.client.conversations_create(name=name, is_private=is_private).data
+
+    def rename_channel(self, channel_id: str, new_name: str) -> Dict:
         """
         Rename an existing channel.
         """
-        api_call = "groups.rename" if is_private else "channels.rename"
 
-        return self.client.api_call(api_call, channel=channel_id, name=new_name, validate=False)
+        return self.client.conversations_rename(channel=channel_id, name=new_name).data
 
-    def get_channel_info(self, channel_id, is_private=False):
+    def get_channel_info(self, channel_id: str) -> Dict:
         """
         Return the channel info of a given channel ID.
         """
 
-        api_call = "conversations.info"
-        return self.client.api_call(api_call, channel=channel_id)
+        return self.client.conversations_info(channel=channel_id).data
 
-    def get_channel_members(self, channel_id, next_cursor=None):
-        """Recursively fetch members of the given channel, until none remain to be fetched"""
-        response = self.client.api_call("conversations.members", channel=channel_id, cursor=next_cursor)
-        members = response['members']
-        next_cursor = response['response_metadata']['next_cursor']
-        if not next_cursor:
-            return members
-        else:
-            return members + self.get_channel_members(channel_id, next_cursor)
+    def get_channel_members(self, channel_id: str) -> List[str]:
+        """ Return list of member ids in a given channel ID. """
 
-    def update_channel_purpose_name(self, channel_id, new_name, is_private=False):
+        members = []
+        for page in self.client.conversations_members(channel=channel_id):
+            members.extend(page['members'])
+
+        return members
+
+    def update_channel_purpose_name(self, channel_id: str, new_name: str) -> Dict:
         """
         Updates the channel purpose 'name' field for a given channel ID.
         """
 
-        # Update channel purpose
-        channel_info = self.get_channel_info(channel_id, is_private)
+        channel_info = self.get_channel_info(channel_id)
 
-        if channel_info:
-            purpose = load_json(channel_info['channel']['purpose']['value'])
-            purpose['name'] = new_name
+        purpose = load_json(channel_info['channel']['purpose']['value'])
+        purpose['name'] = new_name
 
-            self.set_purpose(channel_id, json.dumps(purpose), is_private)
+        return self.set_purpose(channel_id, json.dumps(purpose))
 
-    def post_message(self, channel_id, text, timestamp="", parse="full"):
+    def post_message(self, channel_id: str, text: str, timestamp="", parse="full") -> Dict:
         """
         Post a message in a given channel.
         channel_id can also be a user_id for private messages.
         Add timestamp for replying to a specific message.
         """
-        self.client.api_call("chat.postMessage", channel=channel_id,
-                             text=text, as_user=True, parse=parse, thread_ts=timestamp)
 
-    def post_message_with_react(self, channel_id, text, reaction, parse="full"):
+        return self.client.chat_postMessage(channel=channel_id, text=text, as_user=True, parse=parse,
+                                            thread_ts=timestamp).data
+
+    def post_message_with_react(self, channel_id: str, text: str, reaction: str, parse="full") -> Dict:
         """Post a message in a given channel and add the specified reaction to it."""
-        result = self.client.api_call("chat.postMessage", channel=channel_id, text=text,
-                                      as_user=True, parse=parse)
 
-        if result["ok"]:
-            self.client.api_call("reactions.add", channel=channel_id, name=reaction, timestamp=result["ts"])
+        result = self.post_message(channel_id, text, "", parse)
 
-    def get_message(self, channel_id, timestamp):
+        return self.client.reactions_add(channel=channel_id, name=reaction, timestamp=result["ts"]).data
+
+    def get_message(self, channel_id: str, timestamp: str) -> Dict:
         """Retrieve a message from the channel with the specified timestamp."""
-        return self.client.api_call("channels.history", channel=channel_id, latest=timestamp, count=1, inclusive=True)
 
-    def update_message(self, channel_id, msg_timestamp, text, parse="full"):
+        return self.client.conversations_history(channel=channel_id, latest=timestamp, limit=1, inclusive=True).data
+
+    def update_message(self, channel_id: str, msg_timestamp: str, text: str, parse="full") -> Dict:
         """Update a message, identified by the specified timestamp with a new text."""
-        self.client.api_call("chat.update", channel=channel_id, text=text, ts=msg_timestamp, as_user=True, parse=parse)
 
-    def get_channels(self, types, next_cursor=None):
-        """Recursively fetch channels, until there are no more to be fetched."""
-        types = [types] if type(types) != list else types
-        response = self.client.api_call("conversations.list", types=types, cursor=next_cursor)
-        channels = response['channels']
-        next_cursor = response['response_metadata']['next_cursor']
-        if not next_cursor:
-            return channels
-        else:
-            return channels + self.get_channels(types, next_cursor)
+        return self.client.chat_update(channel=channel_id, ts=msg_timestamp, text=text, as_user=True, parse=parse).data
 
-    def get_all_channels(self):
-        """Fetch all channels."""
-        return self.get_channels(["public_channel", "private_channel"])
+    def get_channels(self, types) -> List[Dict]:
+        """Paginates all channels. Will raise exception if list fails"""
 
-    def get_channel_by_name(self, name):
-        """Fetch a channel with a given name."""
-        channels = self.get_all_channels()
-        for channel in channels:
-            if channel['name'] == name:
-                return channel
+        channels = []
 
-    def get_public_channels(self):
+        for page in self.client.conversations_list(types=types):
+            channels.extend(page['channels'])
+
+        return channels
+
+    def get_public_channels(self) -> List[Dict]:
         """Fetch all public channels."""
-        return self.get_channels("public_channel")
 
-    def get_private_channels(self):
+        return self.get_channels(types="public_channel")
+
+    def get_private_channels(self) -> List[Dict]:
         """Fetch all private channels in which the user participates."""
-        return self.get_channels("private_channel")
 
-    def archive_channel(self, channel_id):
-        """Archive a channel"""
-        return self.client.api_call("conversations.archive", channel=channel_id)
+        return self.get_channels(types="private_channel")
 
-    def archive_private_channel(self, channel_id):
+    def archive_private_channel(self, channel_id: str) -> Dict:
         """Archive a private channel"""
-        return self.client.api_call("groups.archive", channel=channel_id)
 
-    def archive_public_channel(self, channel_id):
+        return self.client.conversations_archive(channel=channel_id).data
+
+    def archive_public_channel(self, channel_id: str) -> Dict:
         """Archive a public channel"""
-        return self.client.api_call("channels.archive", channel=channel_id)
 
-    def add_reminder_hours(self, user, msg, offset):
+        return self.client.conversations_archive(channel=channel_id).data
+
+    def add_reminder_hours(self, user: str, msg: str, offset: str) -> Dict:
         """Add a reminder with a given text for the specified user."""
-        return self.client.api_call("reminders.add", text=msg, time="in {} hours".format(offset), user=user)
 
-    def get_reminders(self):
+        return self.client.reminders_add(text=msg, time=f"in {offset} hours", user=user).data
+
+    def get_reminders(self) -> Dict:
         """Retrieve all reminders created by the bot."""
-        return self.client.api_call("reminders.list")
 
-    def remove_reminder(self, reminder_id):
-        return self.client.api_call("reminders.delete", reminder=reminder_id)
+        return self.client.reminders_list().data
 
-    def remove_reminders_by_text(self, text):
+    def remove_reminder(self, reminder_id: str) -> Dict:
+
+        return self.client.reminders_delete(reminder=reminder_id).data
+
+    def remove_reminders_by_text(self, text: str):
         """Remove all reminders that contain the specified text."""
         reminders = self.get_reminders()
 
-        if reminders and "reminders" in reminders:
-            for reminder in reminders["reminders"]:
-                if text in reminder["text"]:
-                    self.remove_reminder(reminder["id"])
+        for reminder in reminders.get("reminders", []):
+            if text in reminder["text"]:
+                self.remove_reminder(reminder["id"])

--- a/util/slack_wrapper.py
+++ b/util/slack_wrapper.py
@@ -5,7 +5,6 @@ from typing import Any, List, Dict, Union, Sequence
 from slack_sdk import WebClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
-from slack_sdk.web import SlackResponse
 from slack_sdk.socket_mode import SocketModeClient
 
 from util.util import load_json


### PR DESCRIPTION
main changes:
- slack wrapper raises exceptions when paginating, which could be argued is preferred over failing open? can change if you'd rather it return an empty response vs raise an exception

tests are passing except for `test_status` which is also failing on master so I left it be